### PR TITLE
360C-152: Add Bing Webmaster Tools and IndexNow integration

### DIFF
--- a/docs/deployment_summary.md
+++ b/docs/deployment_summary.md
@@ -3,27 +3,15 @@
 <!-- This file is automatically sent via email on successful deployment, then reset for the next cycle -->
 
 ## Latest deploy summary
-- Added **Fort Lee-specific FAQs** to all 6 service pages (2-3 unique questions per service)
-- Added **Local Healthcare Resources section** to all Fort Lee pages featuring:
-  - Holy Name Medical Center
-  - Fort Lee Health Department
-  - Fort Lee Senior Center
-  - CVS Pharmacy
-  - Rite Aid Pharmacy
-- Content differentiation helps Fort Lee pages stand out in local search results
+- Added Bing search engine integration for faster page indexing
+- Site will now automatically notify Bing when new content is published
+- This helps the website appear in Bing, Yahoo, and DuckDuckGo search results faster
 
 ## Notes for internal team
-- This is the first city to receive content differentiation (test city per SEO remediation plan)
-- City-specific FAQs appear above the standard service FAQs in the FAQ section
-- FAQs are included in the schema markup for rich results
-- Pattern established for rolling out to other cities (Ridgewood, Paramus, etc.) once Google indexes these pages
-- Files modified: 6 city content files in `src/lib/content/cities/bergen-county/`
-- Also added FAQ type re-export to enable cleaner imports
+- Added `netlify.toml` with IndexNow plugin configuration
+- Plugin: `netlify-plugin-submit-sitemap` pings Bing and IndexNow on every deploy
+- Bing Webmaster Tools account set up and sitemap submitted
+- Linear ticket: 360C-152
 
 ## Changed URLs
-- https://www.360degreecare.net/services/personal-care/bergen-county/fort-lee
-- https://www.360degreecare.net/services/companion-care/bergen-county/fort-lee
-- https://www.360degreecare.net/services/elder-care/bergen-county/fort-lee
-- https://www.360degreecare.net/services/nursing/bergen-county/fort-lee
-- https://www.360degreecare.net/services/home-health-aides/bergen-county/fort-lee
-- https://www.360degreecare.net/services/staffing/bergen-county/fort-lee
+- https://www.360degreecare.net/

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,20 @@
+# Netlify configuration for 360 Degree Care
+# https://docs.netlify.com/configure-builds/file-based-configuration/
+
+[build]
+  command = "npm run build"
+  publish = ".next"
+
+# Next.js plugin for Netlify (handles SSR, ISR, etc.)
+[[plugins]]
+  package = "@netlify/plugin-nextjs"
+
+# IndexNow plugin - automatically submits sitemap to Bing and IndexNow on deploy
+# This helps get pages indexed faster than waiting for Google
+[[plugins]]
+  package = "netlify-plugin-submit-sitemap"
+
+  [plugins.inputs]
+    baseUrl = "https://www.360degreecare.net"
+    sitemapPath = "/sitemap.xml"
+    providers = ["bing", "indexnow"]


### PR DESCRIPTION
## Summary
- Added `netlify.toml` with IndexNow plugin configuration
- Plugin automatically pings Bing and IndexNow on every deploy
- Helps get pages indexed faster while Google indexing remains blocked
- Bing reaches 65+ demographic who predominantly use Edge/Windows

## Why This Matters
- Google has not indexed new pages in 3+ weeks despite requests
- Bing/IndexNow can index pages in hours vs weeks
- ~9% US search market share, higher among target demographic
- Also feeds DuckDuckGo and Yahoo search results

## Changes
- New file: `netlify.toml` with build configuration and IndexNow plugin

## Test plan
- [ ] Verify Netlify deploy succeeds with new config
- [ ] Check Netlify deploy logs for IndexNow plugin execution
- [ ] Verify pages appear in Bing search within 1 week

## Linear Ticket
https://linear.app/pixelverse-studios/issue/360C-152

🤖 Generated with [Claude Code](https://claude.com/claude-code)