### PR TITLE
360C-159: Add internal links from county hub pages to city pages

### DIFF
--- a/docs/deployment_summary.md
+++ b/docs/deployment_summary.md
@@ -6,6 +6,9 @@
 - Added internal links from all 6 service hub pages to Bergen County city pages
 - New "Service Areas in Bergen County" section now appears on Companion Care, Personal Care, Elder Care, Home Health Aides, Nursing, and Staffing service pages
 - Each section links to all 9 Bergen County cities with keyword-rich anchor text (e.g., "Companion Care in Fort Lee, NJ")
+- Added internal links from all 6 Bergen County hub pages to city-specific service pages
+- New "Services by City" section on county hub pages provides prominent links to Fort Lee, Ridgewood, Paramus, Hackensack, Teaneck, Fair Lawn, Englewood, Westwood, and River Vale pages
+- Links use keyword-rich anchor text (e.g., "Personal Care in Fort Lee, NJ") for SEO benefit
 - Added noindex meta tags to 126 non-Bergen County city pages (Essex, Monmouth, Passaic counties) to focus Google's crawl budget on priority Bergen County pages
 - Fixed 43 legacy URL 404 errors with permanent redirects (51 reported, 8 were stale GSC data for pages that now exist)
 - Added BreadcrumbList JSON-LD schema to all pages with breadcrumb navigation for rich snippet eligibility
@@ -29,6 +32,11 @@
   - Schema auto-generated based on current page path
   - Includes Home and all visible breadcrumb items with absolute URLs
   - Files: src/lib/seo/breadcrumb-schema.ts (new), src/components/nav/Breadcrumbs.tsx
+- 360C-159 completed: Added internal links from Bergen County hub pages to city pages
+  - New `BergenCountyCityLinks` component provides prominent city links section
+  - Added to all 6 Bergen County hub pages (companion-care, personal-care, elder-care, home-health-aides, nursing, staffing)
+  - Each link uses keyword-rich anchor text: "[Service Name] in [City], NJ"
+  - Files: src/components/county/BergenCountyCityLinks.tsx (new), 6 county hub page files
 
 ## Changed URLs
 - https://www.360degreecare.net/services/companion-care
@@ -37,6 +45,12 @@
 - https://www.360degreecare.net/services/home-health-aides
 - https://www.360degreecare.net/services/nursing
 - https://www.360degreecare.net/services/staffing
+- https://www.360degreecare.net/services/companion-care/bergen-county
+- https://www.360degreecare.net/services/personal-care/bergen-county
+- https://www.360degreecare.net/services/elder-care/bergen-county
+- https://www.360degreecare.net/services/home-health-aides/bergen-county
+- https://www.360degreecare.net/services/nursing/bergen-county
+- https://www.360degreecare.net/services/staffing/bergen-county
 - All 108 non-Bergen city pages now have noindex (Essex, Monmouth, Passaic counties)
 - Redirect rules affect 43 legacy URLs (no new page URLs, only redirects)
 - All pages with breadcrumbs now include BreadcrumbList schema (site-wide)

--- a/src/app/services/companion-care/bergen-county/page.tsx
+++ b/src/app/services/companion-care/bergen-county/page.tsx
@@ -3,6 +3,7 @@ import CountyHeroSection from '@/components/county/CountyHeroSection'
 import CountyIntroSection from '@/components/county/CountyIntroSection'
 import RegionalSection from '@/components/county/RegionalSection'
 import ServiceAreaGrid from '@/components/county/ServiceAreaGrid'
+import BergenCountyCityLinks from '@/components/county/BergenCountyCityLinks'
 import CountyCTASection from '@/components/county/CountyCTASection'
 import { bergenCountyCompanionCareContent } from '@/lib/content/bergen-county-companion-care'
 import { getCitySlugs } from '@/lib/content/city-slug-map'
@@ -78,6 +79,12 @@ export default function CompanionCareBergenCountyPage() {
                     regions={content.serviceAreas.regions}
                     linkBase={serviceLinkBase}
                     citySlugs={citySlugs}
+                />
+
+                {/* City-Specific Service Pages */}
+                <BergenCountyCityLinks
+                    serviceSlug="companion-care"
+                    serviceName="Companion Care"
                 />
 
                 {/* Services Section */}

--- a/src/app/services/elder-care/bergen-county/page.tsx
+++ b/src/app/services/elder-care/bergen-county/page.tsx
@@ -3,6 +3,7 @@ import CountyHeroSection from '@/components/county/CountyHeroSection'
 import CountyIntroSection from '@/components/county/CountyIntroSection'
 import RegionalSection from '@/components/county/RegionalSection'
 import ServiceAreaGrid from '@/components/county/ServiceAreaGrid'
+import BergenCountyCityLinks from '@/components/county/BergenCountyCityLinks'
 import CountyCTASection from '@/components/county/CountyCTASection'
 import { bergenCountyElderCareContent } from '@/lib/content/bergen-county-elder-care'
 import { getCitySlugs } from '@/lib/content/city-slug-map'
@@ -78,6 +79,12 @@ export default function ElderCareBergenCountyPage() {
                     regions={content.serviceAreas.regions}
                     linkBase={serviceLinkBase}
                     citySlugs={citySlugs}
+                />
+
+                {/* City-Specific Service Pages */}
+                <BergenCountyCityLinks
+                    serviceSlug="elder-care"
+                    serviceName="Elder Care"
                 />
 
                 {/* Services Section */}

--- a/src/app/services/home-health-aides/bergen-county/page.tsx
+++ b/src/app/services/home-health-aides/bergen-county/page.tsx
@@ -5,6 +5,7 @@ import CountyHeroSection from '@/components/county/CountyHeroSection'
 import CountyIntroSection from '@/components/county/CountyIntroSection'
 import RegionalSection from '@/components/county/RegionalSection'
 import ServiceAreaGrid from '@/components/county/ServiceAreaGrid'
+import BergenCountyCityLinks from '@/components/county/BergenCountyCityLinks'
 import CountyCTASection from '@/components/county/CountyCTASection'
 import { bergenCountyHomeHealthAidesContent } from '@/lib/content/bergen-county-home-health-aides'
 import { getCitySlugs } from '@/lib/content/city-slug-map'
@@ -74,6 +75,12 @@ export default function HomeHealthAidesBergenCountyPage() {
                     regions={content.serviceAreas.regions}
                     linkBase={serviceLinkBase}
                     citySlugs={citySlugs}
+                />
+
+                {/* City-Specific Service Pages */}
+                <BergenCountyCityLinks
+                    serviceSlug="home-health-aides"
+                    serviceName="Home Health Aide"
                 />
 
                 {/* Services Section */}

--- a/src/app/services/nursing/bergen-county/page.tsx
+++ b/src/app/services/nursing/bergen-county/page.tsx
@@ -5,6 +5,7 @@ import CountyHeroSection from '@/components/county/CountyHeroSection'
 import CountyIntroSection from '@/components/county/CountyIntroSection'
 import RegionalSection from '@/components/county/RegionalSection'
 import ServiceAreaGrid from '@/components/county/ServiceAreaGrid'
+import BergenCountyCityLinks from '@/components/county/BergenCountyCityLinks'
 import CountyCTASection from '@/components/county/CountyCTASection'
 import { bergenCountyNursingContent } from '@/lib/content/bergen-county-nursing'
 import { getCitySlugs } from '@/lib/content/city-slug-map'
@@ -73,6 +74,12 @@ export default function NursingBergenCountyPage() {
                     regions={content.serviceAreas.regions}
                     linkBase={serviceLinkBase}
                     citySlugs={citySlugs}
+                />
+
+                {/* City-Specific Service Pages */}
+                <BergenCountyCityLinks
+                    serviceSlug="nursing"
+                    serviceName="Nursing"
                 />
 
                 {/* Services Section */}

--- a/src/app/services/personal-care/bergen-county/page.tsx
+++ b/src/app/services/personal-care/bergen-county/page.tsx
@@ -5,6 +5,7 @@ import CountyHeroSection from '@/components/county/CountyHeroSection'
 import CountyIntroSection from '@/components/county/CountyIntroSection'
 import RegionalSection from '@/components/county/RegionalSection'
 import ServiceAreaGrid from '@/components/county/ServiceAreaGrid'
+import BergenCountyCityLinks from '@/components/county/BergenCountyCityLinks'
 import CountyCTASection from '@/components/county/CountyCTASection'
 import { bergenCountyPersonalCareContent } from '@/lib/content/bergen-county-personal-care'
 import { getCitySlugs } from '@/lib/content/city-slug-map'
@@ -79,6 +80,12 @@ export default function PersonalCareBergenCountyPage() {
                     regions={content.serviceAreas.regions}
                     linkBase={serviceLinkBase}
                     citySlugs={citySlugs}
+                />
+
+                {/* City-Specific Service Pages */}
+                <BergenCountyCityLinks
+                    serviceSlug="personal-care"
+                    serviceName="Personal Care"
                 />
 
                 {/* Services Section */}

--- a/src/app/services/staffing/bergen-county/page.tsx
+++ b/src/app/services/staffing/bergen-county/page.tsx
@@ -5,6 +5,7 @@ import CountyHeroSection from '@/components/county/CountyHeroSection'
 import CountyIntroSection from '@/components/county/CountyIntroSection'
 import RegionalSection from '@/components/county/RegionalSection'
 import ServiceAreaGrid from '@/components/county/ServiceAreaGrid'
+import BergenCountyCityLinks from '@/components/county/BergenCountyCityLinks'
 import CountyCTASection from '@/components/county/CountyCTASection'
 import { bergenCountyStaffingContent } from '@/lib/content/bergen-county-staffing'
 import { getCitySlugs } from '@/lib/content/city-slug-map'
@@ -74,6 +75,12 @@ export default function StaffingBergenCountyPage() {
                     regions={content.serviceAreas.regions}
                     linkBase={serviceLinkBase}
                     citySlugs={citySlugs}
+                />
+
+                {/* City-Specific Service Pages */}
+                <BergenCountyCityLinks
+                    serviceSlug="staffing"
+                    serviceName="Healthcare Staffing"
                 />
 
                 {/* Services Section */}

--- a/src/components/county/BergenCountyCityLinks.tsx
+++ b/src/components/county/BergenCountyCityLinks.tsx
@@ -1,0 +1,79 @@
+import Link from 'next/link'
+import { getCitySlugs } from '@/lib/content/city-slug-map'
+
+type ServiceType =
+    | 'companion-care'
+    | 'personal-care'
+    | 'elder-care'
+    | 'home-health-aides'
+    | 'nursing'
+    | 'staffing'
+
+interface BergenCountyCityLinksProps {
+    serviceSlug: ServiceType
+    serviceName: string
+}
+
+const BERGEN_COUNTY_CITIES: Record<string, string> = {
+    'fort-lee': 'Fort Lee',
+    ridgewood: 'Ridgewood',
+    paramus: 'Paramus',
+    hackensack: 'Hackensack',
+    teaneck: 'Teaneck',
+    'fair-lawn': 'Fair Lawn',
+    englewood: 'Englewood',
+    westwood: 'Westwood',
+    'river-vale': 'River Vale'
+}
+
+export default function BergenCountyCityLinks({
+    serviceSlug,
+    serviceName
+}: BergenCountyCityLinksProps) {
+    const activeCitySlugs = getCitySlugs(serviceSlug, 'bergen-county')
+    const linkBase = `/services/${serviceSlug}/bergen-county`
+
+    if (activeCitySlugs.length === 0) {
+        return null
+    }
+
+    return (
+        <section className="py-16 px-4 bg-primary/5">
+            <div className="container mx-auto max-w-5xl">
+                <div className="text-center mb-10">
+                    <h2 className="text-3xl lg:text-4xl font-bold text-primary mb-4 font-merriweather">
+                        {serviceName} Services by City
+                    </h2>
+                    <p className="text-gray-700 text-lg max-w-2xl mx-auto">
+                        Find {serviceName.toLowerCase()} services in your Bergen
+                        County community. Click below for location-specific
+                        information.
+                    </p>
+                </div>
+
+                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+                    {activeCitySlugs.map(slug => {
+                        const cityName = BERGEN_COUNTY_CITIES[slug]
+                        if (!cityName) return null
+
+                        return (
+                            <Link
+                                key={slug}
+                                href={`${linkBase}/${slug}`}
+                                className="group block p-5 bg-white rounded-lg shadow-sm hover:shadow-md transition-all border border-gray-100 hover:border-primary/20"
+                            >
+                                <span className="text-primary font-semibold group-hover:underline text-lg">
+                                    {serviceName} in {cityName}, NJ
+                                </span>
+                                <p className="text-gray-600 text-sm mt-2">
+                                    Professional {serviceName.toLowerCase()}{' '}
+                                    services for {cityName} families
+                                </p>
+                            </Link>
+                        )
+                    })}
+                </div>
+            </div>
+        </section>
+    )
+}


### PR DESCRIPTION
## Summary
- Adds prominent "Services by City" section to all 6 Bergen County hub pages
- Creates new `BergenCountyCityLinks` component with keyword-rich anchor text (e.g., "Personal Care in Fort Lee, NJ")
- Links to all 9 Bergen County cities: Fort Lee, Ridgewood, Paramus, Hackensack, Teaneck, Fair Lawn, Englewood, Westwood, River Vale
- Fixes orphaned city pages by establishing proper internal linking hierarchy for Google to crawl

## Test plan
- [ ] Verify city links section appears on all 6 Bergen County hub pages
- [ ] Confirm links use correct service name + city format
- [ ] Check that personal-care correctly excludes redirected cities (englewood, paramus, westwood)
- [ ] Validate build succeeds without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)