### PR TITLE
360C-163: Add 11 redirects for legacy /{county}/{city} URLs

### DIFF
--- a/docs/deployment_summary.md
+++ b/docs/deployment_summary.md
@@ -12,6 +12,7 @@
 - Added noindex meta tags to 126 non-Bergen County city pages (Essex, Monmouth, Passaic counties) to focus Google's crawl budget on priority Bergen County pages
 - Fixed 43 legacy URL 404 errors with permanent redirects (51 reported, 8 were stale GSC data for pages that now exist)
 - Added BreadcrumbList JSON-LD schema to all pages with breadcrumb navigation for rich snippet eligibility
+- Added 11 more redirects for legacy /{county}/{city} URL patterns found in GSC crawled-not-indexed report
 
 ## Notes for internal team
 - 360C-158 completed
@@ -37,6 +38,13 @@
   - Added to all 6 Bergen County hub pages (companion-care, personal-care, elder-care, home-health-aides, nursing, staffing)
   - Each link uses keyword-rich anchor text: "[Service Name] in [City], NJ"
   - Files: src/components/county/BergenCountyCityLinks.tsx (new), 6 county hub page files
+- 360C-163 completed: Added 11 redirects for legacy /{county}/{city} URLs from GSC crawled-not-indexed
+  - Bergen County: /bergen-county/east-rutherford, /oakland, /teaneck, /englewood-cliffs, /river-edge
+  - Passaic County: /passaic-county/totowa
+  - Monmouth County: /monmouth-county/atlantic-highlands-borough, /matawan-borough, /long-branch-city, /red-bank-borough
+  - Ocean County: /ocean-county/stafford-township
+  - All redirect to /services (preserves any link equity from old site)
+  - GSC removal submitted for 3 truly dead URLs: /blog/bergen-county, /blog/passaic-county, /services/live-in-care
 
 ## Changed URLs
 - https://www.360degreecare.net/services/companion-care

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -85,11 +85,22 @@ const legacyStandaloneRedirects = [
     { source: '/ocean-county', destination: '/services', permanent: true },
     { source: '/passaic-county', destination: '/services', permanent: true },
 
-    // Legacy /{county}/{city} structure (per Dec 18 2025 GSC 404 export)
+    // Legacy /{county}/{city} structure (per Dec 18-19 2025 GSC exports)
     { source: '/monmouth-county/ocean-township', destination: '/services', permanent: true },
     { source: '/ocean-county/ocean-gate-borough', destination: '/services', permanent: true },
     { source: '/passaic-county/little-falls', destination: '/services', permanent: true },
     { source: '/bergen-county/fairview', destination: '/services', permanent: true },
+    { source: '/bergen-county/east-rutherford', destination: '/services', permanent: true },
+    { source: '/bergen-county/oakland', destination: '/services', permanent: true },
+    { source: '/bergen-county/teaneck', destination: '/services', permanent: true },
+    { source: '/bergen-county/englewood-cliffs', destination: '/services', permanent: true },
+    { source: '/bergen-county/river-edge', destination: '/services', permanent: true },
+    { source: '/passaic-county/totowa', destination: '/services', permanent: true },
+    { source: '/monmouth-county/atlantic-highlands-borough', destination: '/services', permanent: true },
+    { source: '/monmouth-county/matawan-borough', destination: '/services', permanent: true },
+    { source: '/monmouth-county/long-branch-city', destination: '/services', permanent: true },
+    { source: '/monmouth-county/red-bank-borough', destination: '/services', permanent: true },
+    { source: '/ocean-county/stafford-township', destination: '/services', permanent: true },
 
     // Legacy /services/{county} structure
     { source: '/services/bergen-county', destination: '/services', permanent: true },


### PR DESCRIPTION
## Summary
- Adds 11 redirects for legacy `/{county}/{city}` URL patterns found in GSC crawled-not-indexed report
- All redirect to `/services` to preserve any link equity from old site structure

**New redirects:**
- `/bergen-county/east-rutherford`
- `/bergen-county/oakland`
- `/bergen-county/teaneck`
- `/bergen-county/englewood-cliffs`
- `/bergen-county/river-edge`
- `/passaic-county/totowa`
- `/monmouth-county/atlantic-highlands-borough`
- `/monmouth-county/matawan-borough`
- `/monmouth-county/long-branch-city`
- `/monmouth-county/red-bank-borough`
- `/ocean-county/stafford-township`

## GSC Removals (manual)
3 truly dead URLs to be removed from GSC:
- `/blog/bergen-county`
- `/blog/passaic-county`
- `/services/live-in-care`

## Test plan
- [ ] Verify redirects work (curl -I each URL)
- [ ] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)