### PR TITLE
360C-180: Add introBody prop to ServiceHero and update Elder Care page

### DIFF
--- a/src/components/services/ServiceHero.tsx
+++ b/src/components/services/ServiceHero.tsx
@@ -14,6 +14,7 @@ const CallToAction = dynamic(() => import('../CallToAction'), {
 interface ServiceHeroProps {
     header: string
     description: string | ReactNode
+    introBody?: string
     cta: string | ReactNode
     img: ImageProps
 }
@@ -21,6 +22,7 @@ interface ServiceHeroProps {
 export default function ServiceHero({
     header,
     description,
+    introBody,
     cta,
     img
 }: ServiceHeroProps) {
@@ -28,7 +30,8 @@ export default function ServiceHero({
         <section className="page-section grid grid-cols-1 lg:grid-cols-2 gap-6">
             <SlideInSection className="flex flex-col gap-6 items-start">
                 <h1>{header}</h1>
-                <article className="mb-12">{description}</article>
+                <p className="text-xl font-medium text-black">{description}</p>
+                {introBody && <p className="text-lg">{introBody}</p>}
                 <CallToAction
                     buttonLabel={cta}
                     value=""

--- a/src/lib/seo/elderCareConsulting.tsx
+++ b/src/lib/seo/elderCareConsulting.tsx
@@ -162,12 +162,10 @@ const StaticElderCareConsultingData = {
                 <FaArrowRight size={24} className="ml-4" />
             </>
         ),
-        description: (
-            <>
-                Expert guidance to help families navigate elder care decisions
-                with clarity and confidence.
-            </>
-        ),
+        description:
+            'Expert guidance to help families navigate elder care decisions with clarity and confidence.',
+        introBody:
+            "Elder care consulting from 360 Degree Care supports families as they navigate complex decisions for aging loved ones. Our consultants help assess care needs, explore options, coordinate services, and create a clear plan aligned with each family's goals.",
         header: 'Elder Care Consulting in New Jersey',
         img: {
             src: getImgSrc('elder-care-hero') ?? '',


### PR DESCRIPTION
## Summary
- Added optional `introBody` prop to `ServiceHero` component for displaying intro body copy in hero section
- Updated Elder Care Consulting page with intro body copy in hero section
- This establishes the pattern for completing 360C-181 through 360C-185

## Changes
- `src/components/services/ServiceHero.tsx` - Added `introBody` prop to interface, renders after subheadline with `text-lg` styling
- `src/lib/seo/elderCareConsulting.tsx` - Added `introBody` field to hero section

## Test plan
- [ ] Verify Elder Care Consulting page displays intro body paragraph in hero section
- [ ] Verify other service pages still render correctly (no breaking changes)
- [ ] Build passes without errors

## Linear ticket
https://linear.app/pixelverse-studios/issue/360C-180

🤖 Generated with [Claude Code](https://claude.com/claude-code)