### PR TITLE
360C-182: Add introBody to Medical Staffing page hero section

### DIFF
--- a/src/lib/seo/staffingServices.tsx
+++ b/src/lib/seo/staffingServices.tsx
@@ -160,12 +160,10 @@ const StaticStaffingServicesData = {
                 Join the Team <FaArrowRight size={24} className="ml-4" />
             </>
         ),
-        description: (
-            <>
-                Credentialed healthcare professionals to support facilities with
-                short- and long-term staffing needs.
-            </>
-        ),
+        description:
+            'Credentialed healthcare professionals to support facilities with short- and long-term staffing needs.',
+        introBody:
+            '360 Degree Care provides medical staffing solutions for healthcare facilities across New Jersey, including hospitals, rehabilitation centers, and long-term care environments. Our staffing services connect facilities with qualified, credentialed professionals to ensure consistent, reliable patient care.',
         header: 'Medical Staffing Solutions in New Jersey',
         img: {
             src: getImgSrc('staffing_hero') ?? '',


### PR DESCRIPTION
## Summary
- Added `introBody` field to Medical Staffing page hero section

## Changes
- `src/lib/seo/staffingServices.tsx` - Added `introBody` field, converted description from JSX to plain string

## Test plan
- [ ] Verify Medical Staffing page displays intro body paragraph in hero section
- [ ] Build passes without errors

## Linear ticket
https://linear.app/pixelverse-studios/issue/360C-182

🤖 Generated with [Claude Code](https://claude.com/claude-code)