### PR TITLE
360C-181: Add introBody to Personal Care page hero section

### DIFF
--- a/src/lib/seo/personalCare.tsx
+++ b/src/lib/seo/personalCare.tsx
@@ -175,12 +175,10 @@ const StaticPersonalCareData = {
                 <FaArrowRight size={24} className="ml-4" />
             </>
         ),
-        description: (
-            <>
-                Hands-on, in-home support that helps seniors live safely,
-                comfortably, and with dignity.
-            </>
-        ),
+        description:
+            'Hands-on, in-home support that helps seniors live safely, comfortably, and with dignity.',
+        introBody:
+            'Personal care services from 360 Degree Care support seniors and individuals who need help with daily living activities while remaining in the comfort of their own homes. Our caregivers provide respectful, reliable assistance designed to promote independence and overall well-being.',
         header: 'Personal Care Services in New Jersey',
         img: {
             src: getImgSrc('personal-care-hero') ?? '',


### PR DESCRIPTION
## Summary
- Added `introBody` field to Personal Care page hero section

## Changes
- `src/lib/seo/personalCare.tsx` - Added `introBody` field, converted description from JSX to plain string

## Test plan
- [ ] Verify Personal Care page displays intro body paragraph in hero section
- [ ] Build passes without errors

## Linear ticket
https://linear.app/pixelverse-studios/issue/360C-181

🤖 Generated with [Claude Code](https://claude.com/claude-code)