### PR TITLE
Fix general contact form Zod schema validation

### DIFF
--- a/src/utils/contact.ts
+++ b/src/utils/contact.ts
@@ -78,11 +78,13 @@ ContactMap.set('employment', {
     type: 'employment'
 })
 
+const generalFormSchema = z.object(baseSchema)
+
 ContactMap.set('general', {
     description:
         "We're here to answer your questions and discuss how we can help you and your loved ones.",
     initialValues: baseForm,
-    schema: baseSchema,
+    schema: generalFormSchema,
     selectOptions: [],
     type: 'general'
 })


### PR DESCRIPTION
## Summary
- Fixed critical bug where general contact form threw TypeError on every keystroke
- Wrapped `baseSchema` with `z.object()` to create a proper Zod schema

## Problem
The general contact form was passing a plain object to `zodResolver()` instead of a Zod schema, causing:
```
TypeError: o[(intermediate value)] is not a function
```

## Test plan
- [ ] Navigate to `/contact/general`
- [ ] Type in any field - no console errors
- [ ] Submit form successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)