### PR TITLE
Add Google Tag Manager container

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -238,6 +238,13 @@ export default function RootLayout({
                 {isProduction && (
                     <>
                         <Script
+                            id="google-tag-manager"
+                            strategy="afterInteractive"
+                            dangerouslySetInnerHTML={{
+                                __html: `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-PGDVF5CR');`
+                            }}
+                        />
+                        <Script
                             id="google-ads-gtag"
                             strategy="afterInteractive"
                             src="https://www.googletagmanager.com/gtag/js?id=AW-17090471122"
@@ -288,15 +295,25 @@ export default function RootLayout({
                 className={`antialiased ${rubik.variable} ${merriweather.variable}`}
             >
                 {isProduction && (
-                    <noscript>
-                        <img
-                            height="1"
-                            width="1"
-                            style={{ display: 'none' }}
-                            src="https://www.facebook.com/tr?id=668364266032178&ev=PageView&noscript=1"
-                            alt=""
-                        />
-                    </noscript>
+                    <>
+                        <noscript>
+                            <iframe
+                                src="https://www.googletagmanager.com/ns.html?id=GTM-PGDVF5CR"
+                                height="0"
+                                width="0"
+                                style={{ display: 'none', visibility: 'hidden' }}
+                            />
+                        </noscript>
+                        <noscript>
+                            <img
+                                height="1"
+                                width="1"
+                                style={{ display: 'none' }}
+                                src="https://www.facebook.com/tr?id=668364266032178&ev=PageView&noscript=1"
+                                alt=""
+                            />
+                        </noscript>
+                    </>
                 )}
                 <RouteStateProvider>
                     <Suspense fallback={null}>


### PR DESCRIPTION
## Summary
- Added Google Tag Manager container script in head
- Added GTM noscript iframe fallback in body
- Container ID: `GTM-PGDVF5CR`
- Production only

## Test plan
- [ ] Verify GTM loads in production (check Network tab for gtm.js)
- [ ] Verify in GTM Preview mode that container connects

🤖 Generated with [Claude Code](https://claude.com/claude-code)