### PR TITLE
DEV-541: Debrand all blog articles

### DIFF
--- a/docs/deployment_summary.md
+++ b/docs/deployment_summary.md
@@ -14,14 +14,23 @@
 - Updated root layout metadata, canonical URL, and JSON-LD schemas for Haven Home Health
 - Removed client-specific OG image and social media sameAs references
 - Trimmed service area schemas to Bergen County only for demo
+- Debranded all 29 blog articles to Haven Home Health (replaced brand names, author names, phone numbers, emails, and URLs)
 
 ## Notes for internal team
-- DEV-536, DEV-537, DEV-538 completed
+- DEV-536, DEV-537, DEV-538, DEV-541 completed
 - Files: src/utils/constants.ts, src/components/Logo.tsx, public/manifest.json
 - Assets: public/logo.png, public/favicon.ico, public/favicon-*.png, public/apple-touch-icon.png
 - Logo component no longer uses /logo.png image — now renders text with lucide Home icon
 - Stripped GTM (GTM-PGDVF5CR), Google Ads (AW-17090471122), and all conversion tracking from layout.tsx
 - analytics.ts gutted to no-op stubs; ContactForm.tsx no longer calls tracking
+- DEV-541: All 29 blog articles in src/lib/blogs/articles/ debranded
+  - "360 Degree Care" / "360 Care" / "360DC" -> "Haven Home Health"
+  - Author "Jeff DeJoseph" -> "Haven Health Editorial"
+  - Author "360 Degree Care Team" -> "Haven Home Health Team"
+  - Phone (201) 299-4243 -> (555) 123-4567
+  - URLs 360degreecare.net -> haven-home-health.netlify.app
+  - Avatar references updated from 360Logo to /logo.png
 
 ## Changed URLs
 - All pages affected (brand identity is global via layout, footer, and constants)
+- All blog article pages affected by debranding

--- a/src/lib/blogs/articles/2025/aiVsHomeHealthCare.ts
+++ b/src/lib/blogs/articles/2025/aiVsHomeHealthCare.ts
@@ -8,7 +8,7 @@ const aiVsHomeHealthCare = {
         'Artificial intelligence is changing healthcare, but it will never replace the compassion, intuition, and human connection provided by dedicated home health aides.',
     category: 'Industry Insights',
     author: {
-        name: 'Jeff DeJoseph',
+        name: 'Haven Health Editorial',
         title: 'Leader in Aging in Place Services',
         avatar: getImgSrc('Jeff')
     },
@@ -40,7 +40,7 @@ const aiVsHomeHealthCare = {
 
 Artificial intelligence (AI) is revolutionizing many industries—including healthcare. From automating administrative tasks to remotely monitoring vital signs, AI is a powerful tool that’s improving how we deliver care. But no matter how advanced it becomes, AI will never replace the irreplaceable: **the compassionate, intuitive care of a home health aide**.
 
-At [360 Degree Care](https://www.360degreecare.net), we know that **quality elder care** depends on more than just data and technology—it depends on **human connection**.
+At [Haven Home Health](https://haven-home-health.netlify.app), we know that **quality elder care** depends on more than just data and technology—it depends on **human connection**.
 
 ## The Healing Power of Human Touch
 
@@ -63,7 +63,7 @@ Personal care tasks—like bathing, dressing, and feeding—are deeply personal 
 
 ## AI as a Tool—Not a Replacement
 
-At 360 Degree Care, we embrace technology where it helps. AI can **monitor vital signs**, offer **medication reminders**, and streamline documentation. But its role is to **support—not replace—our human caregivers**. The best outcomes in elder care come from **hybrid models**, where AI enhances efficiency and safety, while **home health aides provide the soul and heart of care**.
+At Haven Home Health, we embrace technology where it helps. AI can **monitor vital signs**, offer **medication reminders**, and streamline documentation. But its role is to **support—not replace—our human caregivers**. The best outcomes in elder care come from **hybrid models**, where AI enhances efficiency and safety, while **home health aides provide the soul and heart of care**.
 
 ## Why Human Caregivers Are the Future
 
@@ -73,9 +73,9 @@ The future of **home healthcare** depends on people—committed, compassionate c
 
 > "Care is more than a task. It’s a relationship built on presence, trust, and empathy—qualities that no machine can provide."
 
-If you or a loved one needs personalized in-home care, or you're inspired to make a difference as a caregiver, [learn more about our services and careers](/contact/employment) at 360 Degree Care.
+If you or a loved one needs personalized in-home care, or you're inspired to make a difference as a caregiver, [learn more about our services and careers](/contact/employment) at Haven Home Health.
 
-*Jeff DeJoseph is a leader in the evolving field of aging in place and the services that enable people to remain happy and healthy at home. His company, [360 Degree Care](https://www.360degreecare.net), provides concierge home care services for seniors and those returning from the hospital or rehab.*
+*Haven Home Health is a leader in the evolving field of aging in place and the services that enable people to remain happy and healthy at home, providing concierge home care services for seniors and those returning from the hospital or rehab.*
 `
 }
 

--- a/src/lib/blogs/articles/2025/assistedLivingGuide.ts
+++ b/src/lib/blogs/articles/2025/assistedLivingGuide.ts
@@ -8,7 +8,7 @@ const assistedLivingDecisionGuide = {
         'One of the toughest decisions families face is knowing when it’s time for assisted living. Learn the key signs, comparisons, and steps to plan a compassionate transition.',
     category: 'Senior Care Planning',
     author: {
-        name: 'Jeff DeJoseph',
+        name: 'Haven Health Editorial',
         title: 'Leader in Aging in Place Services',
         avatar: getImgSrc('Jeff')
     },
@@ -101,9 +101,9 @@ Moving a loved one to assisted living is a **major life change**, but it can als
 
 > “The goal isn’t just to find care—it’s to protect dignity, preserve independence, and create a sense of belonging.”
 
-Need help navigating the next steps? [Connect with our care experts](/contact/employment) at 360 Degree Care to explore senior living options that support your loved one's needs.
+Need help navigating the next steps? [Connect with our care experts](/contact/employment) at Haven Home Health to explore senior living options that support your loved one's needs.
 
-*Jeff DeJoseph is a leader in the evolving field of aging in place and the services that enable people to remain happy and healthy at home. His company, [360 Degree Care](https://www.360degreecare.net), provides concierge home care services for seniors and those transitioning from hospital or rehab to home.*
+*Haven Home Health is a leader in the evolving field of aging in place and the services that enable people to remain happy and healthy at home, providing concierge home care services for seniors and those transitioning from hospital or rehab to home.*
 `
 }
 

--- a/src/lib/blogs/articles/2025/chooseHomeCareAgencyBergenCounty.ts
+++ b/src/lib/blogs/articles/2025/chooseHomeCareAgencyBergenCounty.ts
@@ -1,5 +1,3 @@
-import { getImgSrc } from '@/lib/images'
-
 const chooseHomeCareAgencyBergenCounty = {
     id: 'choose-home-care-agency-bergen-county',
     title: "How to Choose a Home Care Agency in Bergen County: A Family's Guide",
@@ -8,9 +6,9 @@ const chooseHomeCareAgencyBergenCounty = {
         'Finding the right home care agency in Bergen County? This guide walks you through what to look for, questions to ask, and red flags to avoid.',
     category: 'Family Care Guides',
     author: {
-        name: '360 Degree Care Team',
+        name: 'Haven Home Health Team',
         title: 'Home Care Specialists',
-        avatar: getImgSrc('360Logo')
+        avatar: '/logo.png'
     },
     publishDate: '2025-01-20',
     readTime: '10 min read',
@@ -40,7 +38,7 @@ const chooseHomeCareAgencyBergenCounty = {
 
 Bergen County has dozens of home care options—from national franchises to local independents, from large operations to family-run businesses. How do you find the right fit for your family?
 
-At 360 Degree Care, we've been serving Bergen County families for years, and we've seen what makes the difference between good care and great care. This guide shares what we've learned—not to sell you on any particular agency, but to help you make an informed choice.
+At Haven Home Health, we've been serving Bergen County families for years, and we've seen what makes the difference between good care and great care. This guide shares what we've learned—not to sell you on any particular agency, but to help you make an informed choice.
 
 ## Start by Understanding What You Need
 
@@ -74,7 +72,7 @@ However, franchise quality can vary significantly by location. The owner and sta
 
 ### Local Independent Agencies
 
-Local agencies like 360 Degree Care are owned and operated within the community. They typically offer more personalized service, direct access to leadership, and deeper community roots.
+Local agencies like Haven Home Health are owned and operated within the community. They typically offer more personalized service, direct access to leadership, and deeper community roots.
 
 The trade-off may be smaller scale, though many families find this is actually a benefit—you're not just another client number.
 
@@ -86,7 +84,7 @@ Some services simply connect families with independent caregivers. The caregiver
 
 Bergen County is large and diverse. An agency based in southern Bergen County may serve northern Bergen County but might not have the same presence or response time. Consider where the agency is headquartered and whether they have caregivers in your specific area.
 
-At 360 Degree Care, we're based in Ridgewood and serve communities throughout Bergen and Passaic Counties, including Paramus, Fort Lee, Hackensack, Teaneck, Englewood, and surrounding towns.
+At Haven Home Health, we're based in Ridgewood and serve communities throughout Bergen and Passaic Counties, including Paramus, Fort Lee, Hackensack, Teaneck, Englewood, and surrounding towns.
 
 ## What to Look for in a Quality Agency
 
@@ -112,7 +110,7 @@ Supervision is equally important. How does the agency ensure care quality over t
 
 Technical competence isn't enough—personality fit matters enormously for day-to-day satisfaction. The best agencies take time to understand your loved one as a person, considering personality and temperament, interests and background, language and cultural factors, specific care preferences, and schedule compatibility.
 
-At 360 Degree Care, we believe this matching process is one of the most important things we do. We're small enough to know every client personally, and we won't send just anyone—we'll send someone we believe is genuinely right for your family.
+At Haven Home Health, we believe this matching process is one of the most important things we do. We're small enough to know every client personally, and we won't send just anyone—we'll send someone we believe is genuinely right for your family.
 
 ### Clear Communication Systems
 
@@ -199,7 +197,7 @@ Practical factors matter too: pricing, scheduling flexibility, proximity. But do
 
 Trust your instincts. You've been through consultations, asked questions, and observed interactions. If something feels off about an agency, even if you can't articulate why, listen to that feeling.
 
-## Why Families Choose 360 Degree Care
+## Why Families Choose Haven Home Health
 
 We'll be honest: we'd love to be the agency you choose. Here's what makes us different.
 
@@ -216,7 +214,7 @@ We'll be honest: we'd love to be the agency you choose. Here's what makes us dif
 ## Frequently Asked Questions
 
 **How long does it take to start home care services?**
-This varies by agency and situation. Some agencies can begin within days; others may take longer. At 360 Degree Care, we move as quickly as possible while ensuring proper assessment and caregiver matching. Emergency situations receive priority.
+This varies by agency and situation. Some agencies can begin within days; others may take longer. At Haven Home Health, we move as quickly as possible while ensuring proper assessment and caregiver matching. Emergency situations receive priority.
 
 **Can we meet caregivers before they start?**
 We encourage this whenever possible. Meeting your caregiver beforehand helps ease the transition for your loved one and gives you confidence in the match. We're happy to arrange introductions.
@@ -228,9 +226,9 @@ You're never locked in. Most agencies require reasonable notice (often one to tw
 
 ## Ready to Find the Right Care for Your Family?
 
-Choosing a home care agency is a significant decision, and you deserve an agency that treats it that way. At 360 Degree Care, we're here to answer your questions, address your concerns, and help you determine if we're the right fit—no pressure, no obligation.
+Choosing a home care agency is a significant decision, and you deserve an agency that treats it that way. At Haven Home Health, we're here to answer your questions, address your concerns, and help you determine if we're the right fit—no pressure, no obligation.
 
-[Contact us to schedule a consultation](/contact/services) or call [(201) 299-4243](tel:2012994243). We serve families throughout Bergen County and Passaic County, providing personalized care that helps your loved one thrive at home. Let's talk about what your family needs.`
+[Contact us to schedule a consultation](/contact/services) or call [(555) 123-4567](tel:5551234567). We serve families throughout Bergen County and Passaic County, providing personalized care that helps your loved one thrive at home. Let's talk about what your family needs.`
 }
 
 export default chooseHomeCareAgencyBergenCounty

--- a/src/lib/blogs/articles/2025/chooseRightHomeCareBergenPassaic.ts
+++ b/src/lib/blogs/articles/2025/chooseRightHomeCareBergenPassaic.ts
@@ -8,7 +8,7 @@ const chooseRightHomeCareBergenPassaic = {
         'A practical NJ senior home care guide for families in Bergen and Passaic County—complete with licensing details, interview questions, and red flags to avoid.',
     category: 'Family Care Guides',
     author: {
-        name: 'Jeff DeJoseph',
+        name: 'Haven Health Editorial',
         title: 'Leader in Aging in Place Services',
         avatar: getImgSrc('Jeff')
     },
@@ -132,7 +132,7 @@ These partners often appreciate ready-made guides they can link to or print, cre
 
 ## Ready to Compare Agencies?
 
-Choosing between multiple agencies can still feel overwhelming. 360 Degree Care offers:
+Choosing between multiple agencies can still feel overwhelming. Haven Home Health offers:
 
 - **Concierge-level personal and companion care** throughout Bergen and Passaic County.
 - **Nurse-led care planning** that aligns with your physician team.
@@ -140,7 +140,7 @@ Choosing between multiple agencies can still feel overwhelming. 360 Degree Care 
 
 Need personalized help applying this checklist? [Contact our local team](/contact/services) and we’ll walk through your scenario, share references, and design a care plan that keeps your loved one safe at home in northern New Jersey.
 
-*Jeff DeJoseph is a leader in the evolving field of aging in place and the services that enable people to remain happy and healthy at home. His company, [360 Degree Care](https://www.360degreecare.net), provides concierge home care services for seniors and those transitioning from hospital or rehab to home.*
+*Haven Home Health is a leader in the evolving field of aging in place and the services that enable people to remain happy and healthy at home, providing concierge home care services for seniors and those transitioning from hospital or rehab to home.*
 `
 }
 

--- a/src/lib/blogs/articles/2025/costHomeCareNorthernNJ.ts
+++ b/src/lib/blogs/articles/2025/costHomeCareNorthernNJ.ts
@@ -8,7 +8,7 @@ const costHomeCareNorthernNJ = {
         'Break down hourly, daily, and monthly pricing for Bergen and Passaic County home care—including cost drivers, assisted living comparisons, and funding options.',
     category: 'Family Care Guides',
     author: {
-        name: 'Jeff DeJoseph',
+        name: 'Haven Health Editorial',
         title: 'Leader in Aging in Place Services',
         avatar: getImgSrc('Jeff')
     },
@@ -61,7 +61,7 @@ Budget discussions should start with the specific care plan—not statewide aver
 | Live-In (single aide) | **$360–$420/day** | 24-hour coverage with mandated sleep breaks and meals |
 | Nurse Visit (RN) | **$150–$225/visit** | Assessments, wound care check-ins, care plan updates |
 
-> *These numbers reflect 360 Degree Care’s market research from Q2 2025. Individual agencies may sit slightly above or below based on shift length, urgency, and bundled services.*
+> *These numbers reflect Haven Home Health’s market research from Q2 2025. Individual agencies may sit slightly above or below based on shift length, urgency, and bundled services.*
 
 ### Billing Variables to Ask About
 
@@ -128,7 +128,7 @@ Feel free to reference or link to this guide in budget planning articles, caregi
 
 ## Need Real Numbers for Your Situation?
 
-360 Degree Care delivers concierge-level companion, personal, and nurse-directed care across Bergen and Passaic Counties. We:
+Haven Home Health delivers concierge-level companion, personal, and nurse-directed care across Bergen and Passaic Counties. We:
 
 - Conduct **same-week RN assessments** to define accurate hour counts
 - Provide **transparent rate sheets** (no surprise surcharges)
@@ -136,7 +136,7 @@ Feel free to reference or link to this guide in budget planning articles, caregi
 
 [Contact us](/contact/services) for a customized cost breakdown and scheduling plan that keeps your loved one safe—and your budget predictable.
 
-*Jeff DeJoseph is a leader in the evolving field of aging in place and the services that enable people to remain happy and healthy at home. His company, [360 Degree Care](https://www.360degreecare.net), provides concierge home care services for seniors and those transitioning from hospital or rehab to home.*
+*Haven Home Health is a leader in the evolving field of aging in place and the services that enable people to remain happy and healthy at home, providing concierge home care services for seniors and those transitioning from hospital or rehab to home.*
 `
 }
 

--- a/src/lib/blogs/articles/2025/doesMedicareCoverHomeCareNJ.ts
+++ b/src/lib/blogs/articles/2025/doesMedicareCoverHomeCareNJ.ts
@@ -1,5 +1,3 @@
-import { getImgSrc } from '@/lib/images'
-
 const doesMedicareCoverHomeCareNJ = {
     id: 'does-medicare-cover-home-care-new-jersey',
     title: 'Does Medicare Cover Home Care in New Jersey? What Families Need to Know',
@@ -8,9 +6,9 @@ const doesMedicareCoverHomeCareNJ = {
         "Learn what Medicare does and doesn't cover for home care in New Jersey. Understand the difference between home health care and personal care coverage.",
     category: 'Family Care Guides',
     author: {
-        name: '360 Degree Care Team',
+        name: 'Haven Home Health Team',
         title: 'Home Care Specialists',
-        avatar: getImgSrc('360Logo')
+        avatar: '/logo.png'
     },
     publishDate: '2025-01-15',
     readTime: '7 min read',
@@ -36,7 +34,7 @@ const doesMedicareCoverHomeCareNJ = {
         ]
     },
     contentType: 'markdown',
-    content: `One of the most common questions we hear from families at 360 Degree Care is: "Will Medicare pay for this?" The answer is complicated—and often disappointing.
+    content: `One of the most common questions we hear from families at Haven Home Health is: "Will Medicare pay for this?" The answer is complicated—and often disappointing.
 
 The short version: Medicare has very limited coverage for home care services. Understanding what is and isn't covered can save you frustration and help you plan realistically for your loved one's care.
 
@@ -163,9 +161,9 @@ Most families pay privately (out-of-pocket), use long-term care insurance if the
 
 ## Need Help Understanding Your Options?
 
-Medicare coverage is confusing, and the gap between what families expect and what's actually covered catches many by surprise. At 360 Degree Care, we help Bergen County and Passaic County families understand their options and create care plans that work within their resources.
+Medicare coverage is confusing, and the gap between what families expect and what's actually covered catches many by surprise. At Haven Home Health, we help Bergen County and Passaic County families understand their options and create care plans that work within their resources.
 
-[Contact us to discuss care options and costs](/contact/services) or call [(201) 299-4243](tel:2012994243). We provide the [personal care](/services/personal-care), [companionship](/services/companion-care), and daily assistance that Medicare doesn't cover—the services that help your loved one live safely and comfortably at home. Let's talk about what your family needs and how to make it work.`
+[Contact us to discuss care options and costs](/contact/services) or call [(555) 123-4567](tel:5551234567). We provide the [personal care](/services/personal-care), [companionship](/services/companion-care), and daily assistance that Medicare doesn't cover—the services that help your loved one live safely and comfortably at home. Let's talk about what your family needs and how to make it work.`
 }
 
 export default doesMedicareCoverHomeCareNJ

--- a/src/lib/blogs/articles/2025/emotionalBenefitsAgingAtHome.ts
+++ b/src/lib/blogs/articles/2025/emotionalBenefitsAgingAtHome.ts
@@ -8,7 +8,7 @@ const emotionalBenefitsAgingAtHome = {
         'Three Bergen and Passaic County families share how concierge home care protected dignity, connection, and peace of mind beyond the medical checklist.',
     category: 'Life at Home',
     author: {
-        name: 'Jeff DeJoseph',
+        name: 'Haven Health Editorial',
         title: 'Leader in Aging in Place Services',
         avatar: getImgSrc('Jeff')
     },
@@ -40,7 +40,7 @@ const emotionalBenefitsAgingAtHome = {
 
 Families researching the **benefits of home care in NJ** or debating whether a loved one can continue **aging in place in Bergen County** or **stay at home with senior care in Passaic County** often focus on logistics: schedules, medications, transportation. Yet the most powerful outcomes we witness are emotional—confidence restored, anxiety calmed, and family relationships renewed.
 
-Below are anonymized stories (shared with permission) from Northern New Jersey households who partnered with 360 Degree Care. Each highlights how personalized home care nurtures mental and emotional well-being, not just physical safety.
+Below are anonymized stories (shared with permission) from Northern New Jersey households who partnered with Haven Home Health. Each highlights how personalized home care nurtures mental and emotional well-being, not just physical safety.
 
 ![Daughter sharing a laugh with her mother at home](mother-daughter)
 *Small moments of connection become easier when daily care tasks feel under control*
@@ -49,7 +49,7 @@ Below are anonymized stories (shared with permission) from Northern New Jersey h
 
 **Situation:** Maria, 82, fractured her hip after a fall at home. Her adult children feared she would need to relocate to assisted living.
 
-**Home care plan:** A Certified Home Health Aide (CHHA) covered mornings and evenings, handling transfers, shower assistance, and medication reminders. A physical therapist visited twice a week, and the care plan was overseen by a 360 Degree Care RN.
+**Home care plan:** A Certified Home Health Aide (CHHA) covered mornings and evenings, handling transfers, shower assistance, and medication reminders. A physical therapist visited twice a week, and the care plan was overseen by a Haven Home Health RN.
 
 **Emotional impact:**
 
@@ -108,7 +108,7 @@ If you run a mental-health nonprofit, senior advocacy organization, or lifestyle
 
 ## Ready to Write Your Family’s Next Chapter?
 
-360 Degree Care designs concierge home care plans across Bergen and Passaic County that prioritize emotional well-being alongside clinical needs. Our team can:
+Haven Home Health designs concierge home care plans across Bergen and Passaic County that prioritize emotional well-being alongside clinical needs. Our team can:
 
 - Match caregivers based on personalities and language preferences
 - Coordinate music, art, or reminiscence therapy add-ons
@@ -116,7 +116,7 @@ If you run a mental-health nonprofit, senior advocacy organization, or lifestyle
 
 [Reach out](/contact/services) to see how home care can help your loved one stay safe, joyful, and connected in Northern New Jersey.
 
-*Jeff DeJoseph is a leader in the evolving field of aging in place and the services that enable people to remain happy and healthy at home. His company, [360 Degree Care](https://www.360degreecare.net), provides concierge home care services for seniors and those transitioning from hospital or rehab to home.*
+*Haven Home Health is a leader in the evolving field of aging in place and the services that enable people to remain happy and healthy at home, providing concierge home care services for seniors and those transitioning from hospital or rehab to home.*
 `
 }
 

--- a/src/lib/blogs/articles/2025/homeCareVsAssistedLivingNJ.ts
+++ b/src/lib/blogs/articles/2025/homeCareVsAssistedLivingNJ.ts
@@ -1,5 +1,3 @@
-import { getImgSrc } from '@/lib/images'
-
 const homeCareVsAssistedLivingNJ = {
     id: 'home-care-vs-assisted-living-nj',
     title: 'Home Care vs. Assisted Living in NJ: Which Is Right for Your Parent?',
@@ -8,9 +6,9 @@ const homeCareVsAssistedLivingNJ = {
         'Comparing home care and assisted living in New Jersey? Learn the costs, benefits, and drawbacks of each to make the best choice for your aging parent.',
     category: 'Family Care Guides',
     author: {
-        name: '360 Degree Care Team',
+        name: 'Haven Home Health Team',
         title: 'Home Care Specialists',
-        avatar: getImgSrc('360Logo')
+        avatar: '/logo.png'
     },
     publishDate: '2025-01-15',
     readTime: '10 min read',
@@ -38,7 +36,7 @@ const homeCareVsAssistedLivingNJ = {
     contentType: 'markdown',
     content: `When an aging parent needs more support than they can manage alone, families face a difficult question: Should they move to assisted living, or receive care at home?
 
-There's no universally right answer. The best choice depends on your parent's needs, preferences, finances, and family situation. At 360 Degree Care, we've helped hundreds of Bergen County and Passaic County families think through this decision.
+There's no universally right answer. The best choice depends on your parent's needs, preferences, finances, and family situation. At Haven Home Health, we've helped hundreds of Bergen County and Passaic County families think through this decision.
 
 This guide compares home care and assisted living across the factors that matter most—so you can make an informed choice for your family.
 
@@ -189,9 +187,9 @@ Resistance is common. Involve their doctor in the conversation—sometimes senio
 
 ## Let's Talk About Your Options
 
-Every family's situation is different. At 360 Degree Care, we help Bergen County and Passaic County families think through their options honestly—including when home care might not be the best fit.
+Every family's situation is different. At Haven Home Health, we help Bergen County and Passaic County families think through their options honestly—including when home care might not be the best fit.
 
-[Contact us for a consultation](/contact/services) or call [(201) 299-4243](tel:2012994243). We'll assess your parent's needs, discuss what home care can provide, and give you straightforward information to support your decision. No pressure, no sales pitch—just honest guidance from people who understand what you're facing.`
+[Contact us for a consultation](/contact/services) or call [(555) 123-4567](tel:5551234567). We'll assess your parent's needs, discuss what home care can provide, and give you straightforward information to support your decision. No pressure, no sales pitch—just honest guidance from people who understand what you're facing.`
 }
 
 export default homeCareVsAssistedLivingNJ

--- a/src/lib/blogs/articles/2025/homeCareVsHomeHealthCare.ts
+++ b/src/lib/blogs/articles/2025/homeCareVsHomeHealthCare.ts
@@ -1,5 +1,3 @@
-import { getImgSrc } from '@/lib/images'
-
 const homeCareVsHomeHealthCare = {
     id: 'home-care-vs-home-health-care',
     title: "Home Care vs. Home Health Care: What's the Difference (And Which Do You Need)?",
@@ -8,9 +6,9 @@ const homeCareVsHomeHealthCare = {
         'Confused about home care vs home health care? Learn the key differences, what each provides, and how to determine which services your loved one needs.',
     category: 'Family Care Guides',
     author: {
-        name: '360 Degree Care Team',
+        name: 'Haven Home Health Team',
         title: 'Home Care Specialists',
-        avatar: getImgSrc('360Logo')
+        avatar: '/logo.png'
     },
     publishDate: '2025-01-15',
     readTime: '7 min read',
@@ -38,7 +36,7 @@ const homeCareVsHomeHealthCare = {
     contentType: 'markdown',
     content: `If you're researching care options for an aging parent or loved one, you've probably noticed that "home care" and "home health care" are often used interchangeably. But they're not the same thing—and understanding the difference is essential for getting your loved one the right support.
 
-At 360 Degree Care, we help Bergen County and Passaic County families navigate these distinctions every day. Let's clear up the confusion.
+At Haven Home Health, we help Bergen County and Passaic County families navigate these distinctions every day. Let's clear up the confusion.
 
 ## The Simple Distinction
 
@@ -135,7 +133,7 @@ Determining which type of care your loved one needs starts with honest assessmen
 4. What does their doctor recommend?
 5. What can we afford, and what might be covered by insurance?
 
-**Consider a professional assessment.** Many families aren't sure where to start, and that's okay. At 360 Degree Care, we offer consultations to help you understand your options and determine the right level of care.
+**Consider a professional assessment.** Many families aren't sure where to start, and that's okay. At Haven Home Health, we offer consultations to help you understand your options and determine the right level of care.
 
 If your loved one needs medical services, we can work alongside home health providers to ensure comprehensive coverage. If non-medical support is what's needed, we'll create a personalized care plan that addresses their specific situation.
 
@@ -154,15 +152,15 @@ Medicare does not cover non-medical home care (personal care, companionship, hou
 Qualification for Medicare-covered home health care requires a doctor's order, a "homebound" status (leaving home is difficult), and a need for skilled nursing or therapy services. Your parent's physician or hospital discharge planner can help determine eligibility.
 
 **Can the same agency provide both home care and home health care?**
-Some larger agencies offer both services, while others specialize in one or the other. At 360 Degree Care, we focus on non-medical home care services and coordinate with home health providers when skilled services are also needed.
+Some larger agencies offer both services, while others specialize in one or the other. At Haven Home Health, we focus on non-medical home care services and coordinate with home health providers when skilled services are also needed.
 
 ---
 
 ## Still Not Sure What Your Loved One Needs?
 
-Navigating care options doesn't have to be overwhelming. At 360 Degree Care, we help Bergen County and Passaic County families understand their options and find the right fit.
+Navigating care options doesn't have to be overwhelming. At Haven Home Health, we help Bergen County and Passaic County families understand their options and find the right fit.
 
-[Contact us for a free consultation](/contact/services) or call [(201) 299-4243](tel:2012994243). Whether your loved one needs personal care, companionship, or you're simply not sure where to start, we're here to help you figure it out—no pressure, no obligations.`
+[Contact us for a free consultation](/contact/services) or call [(555) 123-4567](tel:5551234567). Whether your loved one needs personal care, companionship, or you're simply not sure where to start, we're here to help you figure it out—no pressure, no obligations.`
 }
 
 export default homeCareVsHomeHealthCare

--- a/src/lib/blogs/articles/2025/homecareDecisionShift.ts
+++ b/src/lib/blogs/articles/2025/homecareDecisionShift.ts
@@ -8,7 +8,7 @@ const homecareDecisionShift = {
         "The homecare industry's explosive growth is moderating as Baby Boomers replace the Greatest Generation as primary clients, bringing new economic and cultural challenges.",
     category: 'Industry News',
     author: {
-        name: 'Jeff DeJoseph',
+        name: 'Haven Health Editorial',
         title: 'Leader in Aging in Place Services',
         avatar: getImgSrc('Jeff')
     },
@@ -184,7 +184,7 @@ Whether through affordable, tech-enhanced services or partnerships with ALFs, th
 
 **Ready to navigate the changing landscape of eldercare?** [Contact us](/contact) to explore innovative care solutions that balance independence, affordability, and quality of life for your loved ones.
 
-*This analysis was prepared by Jeff DeJoseph, a leader in the evolving field of aging in place and the services that enable people to remain happy and healthy at home. His company, [360 Degree Care](https://www.360degreecare.net), provides concierge home care services for seniors and those returning from the hospital or rehab.*
+*This analysis was prepared by the Haven Home Health team, leaders in the evolving field of aging in place and the services that enable people to remain happy and healthy at home, providing concierge home care services for seniors and those returning from the hospital or rehab.*
 `
 }
 

--- a/src/lib/blogs/articles/2025/howToPayForHomeCareNJ.ts
+++ b/src/lib/blogs/articles/2025/howToPayForHomeCareNJ.ts
@@ -1,5 +1,3 @@
-import { getImgSrc } from '@/lib/images'
-
 const howToPayForHomeCareNJ = {
     id: 'how-to-pay-for-home-care-nj',
     title: 'How to Pay for Home Care for Elderly Parents in NJ: 7 Options Explained',
@@ -8,9 +6,9 @@ const howToPayForHomeCareNJ = {
         'Struggling to afford home care for aging parents? Learn 7 ways New Jersey families pay for senior care, from insurance to VA benefits to Medicaid.',
     category: 'Family Care Guides',
     author: {
-        name: '360 Degree Care Team',
+        name: 'Haven Home Health Team',
         title: 'Home Care Specialists',
-        avatar: getImgSrc('360Logo')
+        avatar: '/logo.png'
     },
     publishDate: '2025-01-15',
     readTime: '12 min read',
@@ -40,7 +38,7 @@ const howToPayForHomeCareNJ = {
 
 Home care is a significant expense. In New Jersey, families can spend thousands of dollars monthly depending on the level of care needed. But care is also necessary—your parent's safety and quality of life depend on it.
 
-The good news: more options exist than most families realize. At 360 Degree Care, we've helped Bergen County and Passaic County families navigate these financial waters for years. For an overview of what care costs, see our guide on [home care costs in Northern New Jersey](/blog/cost-of-home-care-northern-new-jersey). Here are seven ways families pay for home care, and how to determine which might work for you.
+The good news: more options exist than most families realize. At Haven Home Health, we've helped Bergen County and Passaic County families navigate these financial waters for years. For an overview of what care costs, see our guide on [home care costs in Northern New Jersey](/blog/cost-of-home-care-northern-new-jersey). Here are seven ways families pay for home care, and how to determine which might work for you.
 
 ## 1. Private Pay (Out-of-Pocket)
 
@@ -271,9 +269,9 @@ In some circumstances, yes. Medicaid programs may pay family caregivers. VA bene
 
 ## Let's Discuss Your Options
 
-Paying for home care is challenging, but options exist. At 360 Degree Care, we work with Bergen County and Passaic County families to create care plans that fit both needs and budgets. For more information, visit our [How to Pay](/how-to-pay) page.
+Paying for home care is challenging, but options exist. At Haven Home Health, we work with Bergen County and Passaic County families to create care plans that fit both needs and budgets. For more information, visit our [How to Pay](/how-to-pay) page.
 
-[Contact us for a consultation](/contact/services) or call [(201) 299-4243](tel:2012994243). We're happy to discuss what care your parent needs and help you think through how to fund it sustainably. There's no obligation—just honest conversation about your options.`
+[Contact us for a consultation](/contact/services) or call [(555) 123-4567](tel:5551234567). We're happy to discuss what care your parent needs and help you think through how to fund it sustainably. There's no obligation—just honest conversation about your options.`
 }
 
 export default howToPayForHomeCareNJ

--- a/src/lib/blogs/articles/2025/immigrantsHomeHealthcare.ts
+++ b/src/lib/blogs/articles/2025/immigrantsHomeHealthcare.ts
@@ -8,7 +8,7 @@ const immigrantsHomeHealthcare = {
         'The home healthcare industry increasingly relies on immigrant workers to fill critical roles. From personal care aides to nurses, immigrants are the backbone of this sector, providing compassionate care and addressing labor shortages.',
     category: 'Healthcare Workforce',
     author: {
-        name: 'Jeff DeJoseph',
+        name: 'Haven Health Editorial',
         title: 'Leader in Aging in Place Services',
         avatar: getImgSrc('Jeff')
     },
@@ -249,7 +249,7 @@ We don't just strengthen the home healthcare industry—we honor the essential c
 
 ## Need Expert Guidance on Home Care?
 
-At 360° Care, we understand the complexities of finding and retaining quality home care workers. Our network includes skilled, compassionate caregivers from diverse backgrounds who are committed to providing exceptional care.
+At Haven Home Health, we understand the complexities of finding and retaining quality home care workers. Our network includes skilled, compassionate caregivers from diverse backgrounds who are committed to providing exceptional care.
 
 **We can help you:**
 - Find qualified, reliable home care workers
@@ -262,7 +262,7 @@ Don't navigate the complex world of home care alone. Contact us for a free consu
 
 Call us at [phone number] or [schedule your consultation online](/contact/services).
 
-*Jeff DeJoseph leads 360° Care, a comprehensive elder care consulting and home care service dedicated to helping families navigate the complexities of aging in place. With deep understanding of the home healthcare workforce, we connect families with the skilled, compassionate caregivers who make aging at home possible.*`
+*Haven Home Health is a comprehensive elder care consulting and home care service dedicated to helping families navigate the complexities of aging in place. With deep understanding of the home healthcare workforce, we connect families with the skilled, compassionate caregivers who make aging at home possible.*`
 }
 
 export default immigrantsHomeHealthcare

--- a/src/lib/blogs/articles/2025/lateLifeCrisis.ts
+++ b/src/lib/blogs/articles/2025/lateLifeCrisis.ts
@@ -8,7 +8,7 @@ const lateLifeCrisis = {
         'For adult children of aging parents, finding quality in-home care in New Jersey can be overwhelming. Discover how concierge-level services offer peace of mind and maintain dignity.',
     category: 'Senior Care',
     author: {
-        name: 'Jeff DeJoseph',
+        name: 'Haven Health Editorial',
         title: 'Leader in Aging in Place Services',
         avatar: getImgSrc('Jeff')
     },

--- a/src/lib/blogs/articles/2025/licensedHomeHealthAideVisitNJ.ts
+++ b/src/lib/blogs/articles/2025/licensedHomeHealthAideVisitNJ.ts
@@ -8,7 +8,7 @@ const licensedHomeHealthAideVisitNJ = {
         'See how NJ-certified home health aides are trained, supervised, and supported so every visit feels safe, professional, and transparent for your family.',
     category: 'Care Quality',
     author: {
-        name: 'Jeff DeJoseph',
+        name: 'Haven Health Editorial',
         title: 'Leader in Aging in Place Services',
         avatar: getImgSrc('Jeff')
     },
@@ -46,7 +46,7 @@ Inviting someone into your home is personal—and the stakes feel even higher wh
 ## 1. Licensing and Training Come First
 
 - **State requirements:** New Jersey mandates 76+ hours of classroom and clinical training plus a competency exam under the NJ Board of Nursing. Fingerprinting, background checks, and continuing education are non-negotiable.
-- **360 Degree Care add-ons:** We layer skills labs for transfers, dementia care, and chronic-condition alerts that reflect Bergen, Passaic, Essex, and Monmouth County client needs.
+- **Haven Home Health add-ons:** We layer skills labs for transfers, dementia care, and chronic-condition alerts that reflect Bergen, Passaic, Essex, and Monmouth County client needs.
 - **Documentation:** Credentials, CE logs, and nurse supervision records stay on file and are reviewed before an aide is matched with your family.
 
 ## 2. Vetting and Matching the Right Aide
@@ -104,11 +104,11 @@ Yes, if driving is on the care plan and the aide carries the proper insurance. O
 
 ## Ready for a Visit That Inspires Confidence?
 
-Families across Bergen, Passaic, Essex, Monmouth, and Ocean counties rely on 360 Degree Care because every CHHA visit is backed by licensed supervision, transparent communication, and compassionate professionals.
+Families across Bergen, Passaic, Essex, Monmouth, and Ocean counties rely on Haven Home Health because every CHHA visit is backed by licensed supervision, transparent communication, and compassionate professionals.
 
 [Request a home health aide introduction](/contact/services) and we will design a visit plan tailored to your loved one's routines.
 
-*Jeff DeJoseph is a leader in the evolving field of aging in place and the services that enable people to remain happy and healthy at home. His company, [360 Degree Care](https://www.360degreecare.net), provides concierge home care services for seniors and those transitioning from hospital or rehab to home.*
+*Haven Home Health is a leader in the evolving field of aging in place and the services that enable people to remain happy and healthy at home, providing concierge home care services for seniors and those transitioning from hospital or rehab to home.*
 `
 }
 

--- a/src/lib/blogs/articles/2025/needMoreCareThanProvided.ts
+++ b/src/lib/blogs/articles/2025/needMoreCareThanProvided.ts
@@ -8,7 +8,7 @@ const needMoreCareBlog = {
         'Adult children are struggling to navigate care decisions for aging parents. Professional elder care consulting reduces family stress and improves outcomes through expert guidance.',
     category: 'Elder Care Planning',
     author: {
-        name: 'Jeff DeJoseph',
+        name: 'Haven Health Editorial',
         title: 'Leader in Aging in Place Services',
         avatar: getImgSrc('Jeff')
     },
@@ -217,7 +217,7 @@ Your parents spent decades taking care of you. Now it's your turn. But that does
 
 Call us at [phone number] or [schedule your consultation online](/contact/services). Your family deserves expert guidance during this important transition.
 
-*Jeff DeJoseph is a leader in the evolving field of aging in place and the services that enable people to remain happy and healthy at home. His company, [360 Degree Care](https://www.360degreecare.net), provides comprehensive elder care consulting and concierge home care services for families throughout New Jersey.*`
+*Haven Home Health is a leader in the evolving field of aging in place and the services that enable people to remain happy and healthy at home, providing comprehensive elder care consulting and concierge home care services for families throughout New Jersey.*`
 }
 
 export default needMoreCareBlog

--- a/src/lib/blogs/articles/2025/njCaregiverBurnoutReport.ts
+++ b/src/lib/blogs/articles/2025/njCaregiverBurnoutReport.ts
@@ -8,7 +8,7 @@ const njCaregiverBurnoutReport = {
         'County-level data from Essex, Monmouth, and Passaic shows the top stressors hitting New Jersey caregivers this year—and the actions families can take right now.',
     category: 'Caregiving Guides',
     author: {
-        name: 'Jeff DeJoseph',
+        name: 'Haven Health Editorial',
         title: 'Leader in Aging in Place Services',
         avatar: getImgSrc('Jeff')
     },
@@ -37,7 +37,7 @@ const njCaregiverBurnoutReport = {
     contentType: 'markdown',
     content: `# 2025 Caregiver Burnout Report: What Essex, Monmouth, and Passaic Families Are Facing
 
-New Jersey’s county agencies have been busy surveying family caregivers over the past year. The results highlight the same struggles we hear every day at 360 Degree Care—overwhelm, weather-related interruptions, and a scramble to use local programs before they fill up. Here’s a county-by-county look at the new data, plus practical steps you can start this week.
+New Jersey’s county agencies have been busy surveying family caregivers over the past year. The results highlight the same struggles we hear every day at Haven Home Health—overwhelm, weather-related interruptions, and a scramble to use local programs before they fill up. Here’s a county-by-county look at the new data, plus practical steps you can start this week.
 
 ![Caregiver reviewing a plan with a concierge care manager](reading)
 *A solid plan keeps caregivers informed instead of overwhelmed.*
@@ -88,7 +88,7 @@ Need a template? [Our Essex County companion care team](/services/companion-care
 | Align with county programs | Grants + vouchers refill fast | Call Essex ADRC, Monmouth Office on Aging, or Passaic Senior Services this week |
 | Audit emergency plans | Storms, outages, and evacuations are inevitable | Update go-bags, backup caregivers, and transportation contacts every season |
 
-## How 360 Degree Care Keeps You Ahead
+## How Haven Home Health Keeps You Ahead
 
 - **Concierge-Level™ coordination** threads county data into every assessment so you don’t have to memorize program deadlines.
 - **Nurse-led care plans** weave private duty nursing, CHHAs, and companions into one schedule—with storm buffers and respite hours in writing.
@@ -96,7 +96,7 @@ Need a template? [Our Essex County companion care team](/services/companion-care
 
 Ready to trade constant firefighting for a care plan that actually fits Essex, Monmouth, or Passaic realities? [Schedule a concierge consultation](/contact/services) and we’ll build a roadmap grounded in the same county data local agencies use.
 
-*Jeff DeJoseph is a leader in the evolving field of aging in place and the services that enable people to remain happy and healthy at home. His company, [360 Degree Care](https://www.360degreecare.net), provides concierge home care services for seniors and those transitioning from hospital or rehab to home.*
+*Haven Home Health is a leader in the evolving field of aging in place and the services that enable people to remain happy and healthy at home, providing concierge home care services for seniors and those transitioning from hospital or rehab to home.*
 `
 }
 

--- a/src/lib/blogs/articles/2025/northJerseyCaregiverRoadmap.ts
+++ b/src/lib/blogs/articles/2025/northJerseyCaregiverRoadmap.ts
@@ -8,7 +8,7 @@ const northJerseyCaregiverRoadmap = {
         "A practical path for Bergen, Passaic, Essex, and Monmouth County families to organize COPD, CHF, diabetes, and Parkinson's care at home without burning out.",
     category: 'Caregiving Guides',
     author: {
-        name: 'Jeff DeJoseph',
+        name: 'Haven Health Editorial',
         title: 'Leader in Aging in Place Services',
         avatar: getImgSrc('Jeff')
     },
@@ -45,7 +45,7 @@ Nearly half of New Jersey adults 65+ manage two or more chronic conditions, acco
 
 ## Step 1: Capture the Whole Picture
 
-1. **Run a 360° intake** – Document diagnoses, medications, baseline vitals, preferred hospitals, and advanced directives in one shared file. Our [contact team](/contact/services) walks through this during onboarding so every nurse, CHHA, and therapist sees the same source of truth.
+1. **Run a comprehensive intake** – Document diagnoses, medications, baseline vitals, preferred hospitals, and advanced directives in one shared file. Our [contact team](/contact/services) walks through this during onboarding so every nurse, CHHA, and therapist sees the same source of truth.
 2. **Highlight escalation triggers** – For COPD that could be pulse-ox dropping below 92%; for heart failure it might be a sudden 3 lb weight gain. Post the trigger list on the fridge.
 3. **Map the care circle** – Include specialists, urgent care preferences, faith leaders, and siblings. Shared phone trees reduce midnight guesswork.
 
@@ -61,7 +61,7 @@ Need help? Our [Bergen County personal care team](/services/personal-care/bergen
 
 | Day | Core Tasks | Who Owns It |
 | --- | --- | --- |
-| Monday | RN med reconciliation + refill check | 360 Degree Care nurse |
+| Monday | RN med reconciliation + refill check | Haven Home Health nurse |
 | Tuesday | Physical therapy homework review | Client + CHHA |
 | Wednesday | Telehealth follow-ups + paperwork | Family caregiver |
 | Thursday | Grocery / meal prep for renal or cardiac diets | Companion aide |
@@ -116,11 +116,11 @@ Care quality tanks when you are running on fumes. Bake these safeguards into the
 
 ## Ready to Breathe Again?
 
-360 Degree Care coordinates nurses, therapists, and aides across Bergen, Passaic, Essex, Monmouth, and Ocean counties—so you do not have to play air-traffic controller alone. We share intake data across campaigns and routes, meaning you repeat your story once and every visitor honors it.
+Haven Home Health coordinates nurses, therapists, and aides across Bergen, Passaic, Essex, Monmouth, and Ocean counties—so you do not have to play air-traffic controller alone. We share intake data across campaigns and routes, meaning you repeat your story once and every visitor honors it.
 
 [Schedule a chronic condition care consult](/contact/services) and we will tailor this roadmap to your family.
 
-*Jeff DeJoseph is a leader in the evolving field of aging in place and the services that enable people to remain happy and healthy at home. His company, [360 Degree Care](https://www.360degreecare.net), provides concierge home care services for seniors and those returning from the hospital or rehab.*
+*Haven Home Health is a leader in the evolving field of aging in place and the services that enable people to remain happy and healthy at home, providing concierge home care services for seniors and those returning from the hospital or rehab.*
 `
 }
 

--- a/src/lib/blogs/articles/2025/nursingHomeDecision.ts
+++ b/src/lib/blogs/articles/2025/nursingHomeDecision.ts
@@ -8,7 +8,7 @@ const nursingHomeDecision = {
         'Deciding to move an aging parent into a nursing home is emotionally complex. Explore the considerations, emotions, and steps involved in making this deeply personal decision.',
     category: 'Elder Care Planning',
     author: {
-        name: 'Jeff DeJoseph',
+        name: 'Haven Health Editorial',
         title: 'Leader in Aging in Place Services',
         avatar: getImgSrc('Jeff')
     },
@@ -242,7 +242,7 @@ By focusing on your parent's safety and well-being, involving them in the proces
 
 ## Need Help Navigating This Decision?
 
-At 360° Care, we understand the complexity of these decisions. Our elder care consulting services can help you:
+At Haven Home Health, we understand the complexity of these decisions. Our elder care consulting services can help you:
 
 - Assess your parent's care needs objectively
 - Explore all available options, including home care
@@ -254,7 +254,7 @@ At 360° Care, we understand the complexity of these decisions. Our elder care c
 
 Call us at [phone number] or [schedule your consultation online](/contact/services).
 
-*Jeff DeJoseph is a leader in the evolving field of aging in place and the services that enable people to remain happy and healthy at home. His company, [360 Degree Care](https://www.360degreecare.net), provides comprehensive elder care consulting and home care services throughout New Jersey, with a passionate commitment to helping families keep their loved ones safely at home whenever possible.*`
+*Haven Home Health is a leader in the evolving field of aging in place and the services that enable people to remain happy and healthy at home, providing comprehensive elder care consulting and home care services throughout New Jersey, with a passionate commitment to helping families keep their loved ones safely at home whenever possible.*`
 }
 
 export default nursingHomeDecision

--- a/src/lib/blogs/articles/2025/politicalGame.ts
+++ b/src/lib/blogs/articles/2025/politicalGame.ts
@@ -8,7 +8,7 @@ const politicalGame = {
         "Making decisions about aging parents often surfaces complex family dynamics, transforming straightforward choices into political minefields. Learn how to navigate family disagreements and prioritize your parent's well-being.",
     category: 'Family Dynamics',
     author: {
-        name: 'Jeff DeJoseph',
+        name: 'Haven Health Editorial',
         title: 'Leader in Aging in Place Services',
         avatar: getImgSrc('Jeff')
     },
@@ -93,9 +93,9 @@ By focusing on **open communication, professional guidance, and your parent's do
 
 > "The best family decisions about aging parents happen when everyone remembers they're on the same team, even when they disagree on the strategy."
 
-If your family is struggling with difficult decisions about aging parent care, [connect with our care experts](/contact/general) at 360 Degree Care. We can provide neutral, professional guidance to help navigate these complex family dynamics.
+If your family is struggling with difficult decisions about aging parent care, [connect with our care experts](/contact/general) at Haven Home Health. We can provide neutral, professional guidance to help navigate these complex family dynamics.
 
-*Jeff DeJoseph is a leader in the evolving field of aging in place and the services that enable people to remain happy and healthy at home. His company, [360 Degree Care](https://www.360degreecare.net), provides concierge home care services for seniors and those returning from the hospital or rehab.*
+*Haven Home Health is a leader in the evolving field of aging in place and the services that enable people to remain happy and healthy at home, providing concierge home care services for seniors and those returning from the hospital or rehab.*
 `
 }
 

--- a/src/lib/blogs/articles/2025/sandwichGeneration.ts
+++ b/src/lib/blogs/articles/2025/sandwichGeneration.ts
@@ -8,7 +8,7 @@ const sandwichGeneration = {
         'GEN S—the Sandwich Generation—is feeling the pressure. Juggling care for aging parents and children is no joke. Discover the emotional and financial strain millions quietly carry.',
     category: 'Caregiving Insights',
     author: {
-        name: 'Jeff DeJoseph',
+        name: 'Haven Health Editorial',
         title: 'Leader in Aging in Place Services',
         avatar: getImgSrc('Jeff')
     },
@@ -113,9 +113,9 @@ Only then can we ensure that those **caught in the middle** aren’t left to sho
 
 > “GEN S is doing it all. Let’s make sure they’re not doing it alone.”
 
-If you're a Gen S-er trying to balance it all, you're not alone. At [360 Degree Care](https://www.360degreecare.net), we see you—and we're here to help. [Explore support resources and caregiving solutions](/contact/employment) that can ease your load.
+If you're a Gen S-er trying to balance it all, you're not alone. At [Haven Home Health](https://haven-home-health.netlify.app), we see you—and we're here to help. [Explore support resources and caregiving solutions](/contact/employment) that can ease your load.
 
-*Jeff DeJoseph is a leader in the evolving field of aging in place and the services that enable people to remain happy and healthy at home. His company, [360 Degree Care](https://www.360degreecare.net), provides concierge home care services for seniors and those returning from the hospital or rehab.*
+*Haven Home Health is a leader in the evolving field of aging in place and the services that enable people to remain happy and healthy at home, providing concierge home care services for seniors and those returning from the hospital or rehab.*
 `
 }
 

--- a/src/lib/blogs/articles/2025/seniorHomeSafetyChecklistNJ.ts
+++ b/src/lib/blogs/articles/2025/seniorHomeSafetyChecklistNJ.ts
@@ -8,7 +8,7 @@ const seniorHomeSafetyChecklistNJ = {
         'Room-by-room improvements—from grab bars to winter-ready entryways—tailored to older Bergen and Passaic County homes so seniors can age in place safely.',
     category: 'Home Safety',
     author: {
-        name: 'Jeff DeJoseph',
+        name: 'Haven Health Editorial',
         title: 'Leader in Aging in Place Services',
         avatar: getImgSrc('Jeff')
     },
@@ -129,7 +129,7 @@ Reciprocal links help residents discover vetted providers while boosting local S
 
 ## Need Help Coordinating Upgrades?
 
-360 Degree Care’s concierge team works with NJ-certified OTs, contractors, and durable medical equipment vendors to turn this checklist into an actionable project plan. We:
+Haven Home Health’s concierge team works with NJ-certified OTs, contractors, and durable medical equipment vendors to turn this checklist into an actionable project plan. We:
 
 - Conduct on-site home safety assessments
 - Coordinate installer schedules around caregiver shifts
@@ -137,7 +137,7 @@ Reciprocal links help residents discover vetted providers while boosting local S
 
 [Contact us](/contact/services) to align home modifications with your loved one’s care needs—before the next storm or slip forces an emergency move.
 
-*Jeff DeJoseph is a leader in the evolving field of aging in place and the services that enable people to remain happy and healthy at home. His company, [360 Degree Care](https://www.360degreecare.net), provides concierge home care services for seniors and those transitioning from hospital or rehab to home.*
+*Haven Home Health is a leader in the evolving field of aging in place and the services that enable people to remain happy and healthy at home, providing concierge home care services for seniors and those transitioning from hospital or rehab to home.*
 `
 }
 

--- a/src/lib/blogs/articles/2025/seniorResourcesBergenPassaic.ts
+++ b/src/lib/blogs/articles/2025/seniorResourcesBergenPassaic.ts
@@ -8,7 +8,7 @@ const seniorResourcesBergenPassaic = {
         'A curated roundup of senior centers, adult day programs, veteran services, dementia networks, and transportation supports serving Bergen and Passaic County families.',
     category: 'Local Guides',
     author: {
-        name: 'Jeff DeJoseph',
+        name: 'Haven Health Editorial',
         title: 'Leader in Aging in Place Services',
         avatar: getImgSrc('Jeff')
     },
@@ -38,7 +38,7 @@ const seniorResourcesBergenPassaic = {
     contentType: 'markdown',
     content: `# 5 Local Resources Every Senior and Family Caregiver Should Know in Bergen and Passaic County
 
-If you’re searching for **senior resources Bergen County**, reliable **Passaic County caregiver support**, or other **local senior programs in NJ**, start with the organizations below. Each delivers practical help—transportation, respite, benefits counseling, or dementia guidance—and most collaborate closely with home care agencies like 360 Degree Care.
+If you’re searching for **senior resources Bergen County**, reliable **Passaic County caregiver support**, or other **local senior programs in NJ**, start with the organizations below. Each delivers practical help—transportation, respite, benefits counseling, or dementia guidance—and most collaborate closely with home care agencies like Haven Home Health.
 
 ## 1. Senior Center Networks (Socialization + Meals)
 
@@ -91,7 +91,7 @@ Share this guide with the organizations above and invite reciprocal links so car
 
 ## Need Help Navigating Referrals?
 
-360 Degree Care collaborates with every organization listed here. We:
+Haven Home Health collaborates with every organization listed here. We:
 
 - Coordinate RN assessments with adult day teams
 - Align home care schedules with paratransit pickup windows
@@ -99,7 +99,7 @@ Share this guide with the organizations above and invite reciprocal links so car
 
 [Reach out](/contact/services) for a concierge-style care plan that connects your loved one to the right Bergen or Passaic County programs without the paperwork headache.
 
-*Jeff DeJoseph is a leader in the evolving field of aging in place and the services that enable people to remain happy and healthy at home. His company, [360 Degree Care](https://www.360degreecare.net), provides concierge home care services for seniors and those transitioning from hospital or rehab to home.*
+*Haven Home Health is a leader in the evolving field of aging in place and the services that enable people to remain happy and healthy at home, providing concierge home care services for seniors and those transitioning from hospital or rehab to home.*
 `
 }
 

--- a/src/lib/blogs/articles/2025/signsParentNeedsHomeCare.ts
+++ b/src/lib/blogs/articles/2025/signsParentNeedsHomeCare.ts
@@ -1,5 +1,3 @@
-import { getImgSrc } from '@/lib/images'
-
 const signsParentNeedsHomeCare = {
     id: 'signs-parent-needs-home-care',
     title: '10 Signs Your Aging Parent May Need Home Care',
@@ -8,9 +6,9 @@ const signsParentNeedsHomeCare = {
         'Not sure if your aging parent needs help at home? Learn the 10 warning signs that indicate it may be time to consider home care services.',
     category: 'Family Care Guides',
     author: {
-        name: '360 Degree Care Team',
+        name: 'Haven Home Health Team',
         title: 'Home Care Specialists',
-        avatar: getImgSrc('360Logo')
+        avatar: '/logo.png'
     },
     publishDate: '2025-01-15',
     readTime: '9 min read',
@@ -40,7 +38,7 @@ const signsParentNeedsHomeCare = {
 
 Recognizing when an aging parent needs help isn't easy. They may downplay struggles to avoid worrying you. You may rationalize what you're seeing because the alternative feels overwhelming. And the line between "normal aging" and "needs intervention" isn't always clear.
 
-At 360 Degree Care, we've walked alongside hundreds of Bergen County and Passaic County families through this exact process. Here are the signs we've learned to watch for—and what they might mean for your family.
+At Haven Home Health, we've walked alongside hundreds of Bergen County and Passaic County families through this exact process. Here are the signs we've learned to watch for—and what they might mean for your family.
 
 ## 1. Declining Personal Hygiene
 
@@ -152,7 +150,7 @@ If you've recognized several of these signs, it's time to take action. Here's a 
 
 **Assess the home environment.** Walk through your parent's home with fresh eyes. Look for safety hazards, signs of neglect, and areas where modifications could help.
 
-**Explore care options.** You don't have to figure this out alone. Home care agencies like 360 Degree Care can help you assess needs and understand options. An in-home evaluation gives you concrete information to work with.
+**Explore care options.** You don't have to figure this out alone. Home care agencies like Haven Home Health can help you assess needs and understand options. An in-home evaluation gives you concrete information to work with.
 
 **Don't wait for a crisis.** The time to arrange support is before a fall, before a missed medication causes hospitalization, before a safety incident changes everything. Proactive planning gives you and your parent more choices.
 
@@ -171,9 +169,9 @@ Absolutely. Many adult children feel they "should" be able to handle their paren
 
 ## Ready to Talk About Your Parent's Needs?
 
-If you're seeing these signs in your parent, we understand how difficult this moment is. At 360 Degree Care, we help Bergen County and Passaic County families navigate these transitions with compassion and practical support.
+If you're seeing these signs in your parent, we understand how difficult this moment is. At Haven Home Health, we help Bergen County and Passaic County families navigate these transitions with compassion and practical support.
 
-[Contact us for a free consultation](/contact/services) or call [(201) 299-4243](tel:2012994243). We'll listen to your concerns, answer your questions, and help you understand what options might be right for your family—with no pressure or obligation. Sometimes the first step is simply talking it through with someone who understands.`
+[Contact us for a free consultation](/contact/services) or call [(555) 123-4567](tel:5551234567). We'll listen to your concerns, answer your questions, and help you understand what options might be right for your family—with no pressure or obligation. Sometimes the first step is simply talking it through with someone who understands.`
 }
 
 export default signsParentNeedsHomeCare

--- a/src/lib/blogs/articles/2025/silverTsunami.ts
+++ b/src/lib/blogs/articles/2025/silverTsunami.ts
@@ -8,7 +8,7 @@ const silverTsunamiAgingWorkforceCrisis = {
         "Every day, 10,000 baby boomers nationwide turn 65. While we've prepared for workforce gaps, we're failing to prepare for the care needs of our aging loved ones.",
     category: 'Industry News',
     author: {
-        name: 'Jeff DeJoseph',
+        name: 'Haven Health Editorial',
         title: 'Leader in Aging in Place Services',
         avatar: getImgSrc('Jeff')
     },
@@ -88,7 +88,7 @@ The question isn't whether this demographic shift will happen—it's already und
 
 **Ready to make a difference in your community?** [Learn about career opportunities](/contact/employment) in home healthcare and discover how you can be part of the solution to the Silver Tsunami.
 
-*Jeff DeJoseph is a leader in the evolving field of aging in place and the services that enable people to remain happy and healthy at home. His company, [360 Degree Care](https://www.360degreecare.net), provides concierge home care services for seniors and those returning from the hospital or rehab.*`
+*Haven Home Health is a leader in the evolving field of aging in place and the services that enable people to remain happy and healthy at home, providing concierge home care services for seniors and those returning from the hospital or rehab.*`
 }
 
 export default silverTsunamiAgingWorkforceCrisis

--- a/src/lib/blogs/articles/2025/transitionalCareHospitalToHome.ts
+++ b/src/lib/blogs/articles/2025/transitionalCareHospitalToHome.ts
@@ -8,7 +8,7 @@ const transitionalCareHospitalToHome = {
         'Understand the post-discharge playbook—from hospital orders to in-home nursing oversight—that keeps Bergen and Passaic County seniors from bouncing back to the ER.',
     category: 'Care Transitions',
     author: {
-        name: 'Jeff DeJoseph',
+        name: 'Haven Health Editorial',
         title: 'Leader in Aging in Place Services',
         avatar: getImgSrc('Jeff')
     },
@@ -55,7 +55,7 @@ Here’s what an effective hospital-to-home journey looks like when concierge ho
 
 ## Step 2: Transitional Care Team Handoff
 
-360 Degree Care assigns a dedicated **Transitional Care Coordinator** who:
+Haven Home Health assigns a dedicated **Transitional Care Coordinator** who:
 
 - Reviews the discharge packet with the family
 - Schedules an **RN start-of-care visit** (often within 24–48 hours)
@@ -132,7 +132,7 @@ Reciprocal links signal to patients that your organization collaborates with vet
 
 ## Ready to Coordinate Your Next Transition?
 
-360 Degree Care delivers **home recovery services for Bergen County and Passaic County seniors** with:
+Haven Home Health delivers **home recovery services for Bergen County and Passaic County seniors** with:
 
 - Same-week RN start-of-care visits
 - 24/7 on-call clinical leadership for urgent questions
@@ -140,7 +140,7 @@ Reciprocal links signal to patients that your organization collaborates with vet
 
 [Reach out](/contact/services) before discharge day to set up a seamless **transitional home care** experience—and keep your loved one on the road to recovery at home.
 
-*Jeff DeJoseph is a leader in the evolving field of aging in place and the services that enable people to remain happy and healthy at home. His company, [360 Degree Care](https://www.360degreecare.net), provides concierge home care services for seniors and those transitioning from hospital or rehab to home.*
+*Haven Home Health is a leader in the evolving field of aging in place and the services that enable people to remain happy and healthy at home, providing concierge home care services for seniors and those transitioning from hospital or rehab to home.*
 `
 }
 

--- a/src/lib/blogs/articles/2025/whatDoesHomeHealthAideDo.ts
+++ b/src/lib/blogs/articles/2025/whatDoesHomeHealthAideDo.ts
@@ -6,7 +6,7 @@ const whatDoesHomeHealthAideDo = {
         'Learn what home health aides do, their daily duties, and how they help seniors stay safe at home. Discover if HHA services are right for your family.',
     category: 'Family Care Guides',
     author: {
-        name: '360 Degree Care Team',
+        name: 'Haven Home Health Team',
         title: 'Home Care Specialists',
         avatar: '/logo.png'
     },
@@ -36,7 +36,7 @@ const whatDoesHomeHealthAideDo = {
     contentType: 'markdown',
     content: `When a loved one needs help at home, "home health aide" is often one of the first terms you'll encounter. But what exactly does a home health aide do? Understanding their role—and how it differs from other types of caregivers—is essential for making the right care decision for your family.
 
-At 360 Degree Care, we've helped hundreds of Bergen County and Passaic County families navigate these questions. Based in Ridgewood and serving communities throughout Northern New Jersey, we understand the unique needs of families in our area. In this guide, we'll walk you through everything a home health aide can (and can't) do, so you know exactly what to expect.
+At Haven Home Health, we've helped hundreds of Bergen County and Passaic County families navigate these questions. Based in Ridgewood and serving communities throughout Northern New Jersey, we understand the unique needs of families in our area. In this guide, we'll walk you through everything a home health aide can (and can't) do, so you know exactly what to expect.
 
 ## What Is a Home Health Aide?
 
@@ -151,7 +151,7 @@ The earlier you arrange support, the safer your loved one will be—and the more
 
 ## Finding the Right Home Health Aide in Bergen County and Passaic County
 
-Choosing a home health aide is a significant decision. At 360 Degree Care, we understand that you're not just hiring a caregiver—you're inviting someone into your family's life during a vulnerable time.
+Choosing a home health aide is a significant decision. At Haven Home Health, we understand that you're not just hiring a caregiver—you're inviting someone into your family's life during a vulnerable time.
 
 As a family-run agency based in Ridgewood, we take the time to understand each client's unique needs, preferences, and personality. We don't believe in one-size-fits-all care. Every care plan we create is tailored specifically to your loved one.
 
@@ -172,9 +172,9 @@ Home care (sometimes called non-medical home care) includes personal care, compa
 
 ## Ready to Learn More?
 
-If you're considering home health aide services for a loved one in Bergen County, Passaic County, or the surrounding Northern New Jersey area, we're here to help you understand your options. At 360 Degree Care, we treat every client like family—because that's how we'd want our own loved ones to be treated.
+If you're considering home health aide services for a loved one in Bergen County, Passaic County, or the surrounding Northern New Jersey area, we're here to help you understand your options. At Haven Home Health, we treat every client like family—because that's how we'd want our own loved ones to be treated.
 
-[Schedule a free consultation](/contact/services) or call us at [(201) 299-4243](tel:2012994243) to discuss your family's needs and learn how a home health aide can help your loved one thrive at home.`
+[Schedule a free consultation](/contact/services) or call us at [(555) 123-4567](tel:5551234567) to discuss your family's needs and learn how a home health aide can help your loved one thrive at home.`
 }
 
 export default whatDoesHomeHealthAideDo

--- a/src/lib/blogs/articles/2025/whatIsRespiteCare.ts
+++ b/src/lib/blogs/articles/2025/whatIsRespiteCare.ts
@@ -1,5 +1,3 @@
-import { getImgSrc } from '@/lib/images'
-
 const whatIsRespiteCare = {
     id: 'what-is-respite-care',
     title: 'What Is Respite Care and How Can It Help Family Caregivers?',
@@ -8,9 +6,9 @@ const whatIsRespiteCare = {
         'Learn what respite care is, how it helps family caregivers, and when to consider taking a break. Essential guide for anyone caring for an aging loved one.',
     category: 'Family Care Guides',
     author: {
-        name: '360 Degree Care Team',
+        name: 'Haven Home Health Team',
         title: 'Home Care Specialists',
-        avatar: getImgSrc('360Logo')
+        avatar: '/logo.png'
     },
     publishDate: '2025-01-15',
     readTime: '8 min read',
@@ -54,7 +52,7 @@ Respite care can take several forms. **In-home respite** is when a professional 
 
 **Short-term residential care** at assisted living facilities or nursing homes offers temporary stays, sometimes called "respite stays," for longer breaks like vacations.
 
-At 360 Degree Care, we focus on in-home respite care—sending trained caregivers to your loved one's home so you can take the break you need while knowing they're in good hands.
+At Haven Home Health, we focus on in-home respite care—sending trained caregivers to your loved one's home so you can take the break you need while knowing they're in good hands.
 
 ## Why Respite Care Matters
 
@@ -84,7 +82,7 @@ If you're nodding along to several of these, you need a break—not eventually, 
 
 ### In-Home Respite Care
 
-When you arrange in-home respite care through an agency like 360 Degree Care, here's what typically happens:
+When you arrange in-home respite care through an agency like Haven Home Health, here's what typically happens:
 
 **Assessment:** We learn about your loved one's needs, routines, and preferences. We also understand your situation—what kind of break do you need? A few hours weekly? A long weekend? Coverage while you travel?
 
@@ -169,9 +167,9 @@ There may be initial adjustment, especially for those with dementia. But most ol
 
 Family caregiving is an act of love. But love doesn't require sacrificing your own wellbeing. Respite care gives you space to breathe, recharge, and continue caring for the long haul.
 
-At 360 Degree Care, we provide respite care for families throughout Bergen County and Passaic County. We understand that trusting someone new with your loved one is a big step, and we take that responsibility seriously.
+At Haven Home Health, we provide respite care for families throughout Bergen County and Passaic County. We understand that trusting someone new with your loved one is a big step, and we take that responsibility seriously.
 
-[Contact us to discuss respite care options](/contact/services) or call [(201) 299-4243](tel:2012994243). Let's talk about what kind of break you need and how we can help make it happen. You've earned it.`
+[Contact us to discuss respite care options](/contact/services) or call [(555) 123-4567](tel:5551234567). Let's talk about what kind of break you need and how we can help make it happen. You've earned it.`
 }
 
 export default whatIsRespiteCare

--- a/src/lib/blogs/articles/2025/whoCares.ts
+++ b/src/lib/blogs/articles/2025/whoCares.ts
@@ -8,7 +8,7 @@ const whoCares = {
         "Caregivers pour their hearts into caring for senior family members, but who's looking out for them? Learn why supporting caregivers is essential for sustainable care and family well-being.",
     category: 'Caregiver Support',
     author: {
-        name: 'Jeff DeJoseph',
+        name: 'Haven Health Editorial',
         title: 'Leader in Aging in Place Services',
         avatar: getImgSrc('Jeff')
     },
@@ -74,9 +74,9 @@ By providing **emotional, practical, health-focused, and financial support**, we
 
 > "You cannot pour from an empty cup. Supporting caregivers isn't just compassionate—it's essential for sustainable care."
 
-If you're a caregiver feeling overwhelmed, or if you want to support a caregiver in your life, [connect with our care experts](/contact/employment) at 360 Degree Care. We understand the challenges and we're here to help.
+If you're a caregiver feeling overwhelmed, or if you want to support a caregiver in your life, [connect with our care experts](/contact/employment) at Haven Home Health. We understand the challenges and we're here to help.
 
-*Jeff DeJoseph is a leader in the evolving field of aging in place and the services that enable people to remain happy and healthy at home. His company, [360 Degree Care](https://www.360degreecare.net), provides concierge home care services for seniors and those returning from the hospital or rehab.*
+*Haven Home Health is a leader in the evolving field of aging in place and the services that enable people to remain happy and healthy at home, providing concierge home care services for seniors and those returning from the hospital or rehab.*
 `
 }
 

--- a/src/lib/blogs/articles/2026/questionsToAskHomeCareAgency.ts
+++ b/src/lib/blogs/articles/2026/questionsToAskHomeCareAgency.ts
@@ -1,5 +1,3 @@
-import { getImgSrc } from '@/lib/images'
-
 const questionsToAskHomeCareAgency = {
     id: 'questions-to-ask-home-care-agency',
     title: '15 Questions to Ask Before Hiring a Home Care Agency in Bergen County',
@@ -8,9 +6,9 @@ const questionsToAskHomeCareAgency = {
         'Essential questions to ask before hiring a home care agency in Bergen County, NJ. Use this checklist to find the right caregiver for your loved one.',
     category: 'Family Care Guides',
     author: {
-        name: '360 Degree Care Team',
+        name: 'Haven Home Health Team',
         title: 'Home Care Specialists',
-        avatar: getImgSrc('360Logo')
+        avatar: '/logo.png'
     },
     publishDate: '2025-01-15',
     readTime: '10 min read',
@@ -40,7 +38,7 @@ const questionsToAskHomeCareAgency = {
 
 With dozens of home care agencies serving Bergen County, Passaic County, and surrounding Northern New Jersey communities, how do you separate the exceptional from the mediocre? You ask the right questions.
 
-At 360 Degree Care, we welcome tough questions from families—it shows you're serious about finding the best care. Below are the 15 questions every family should ask before signing with any home care agency.
+At Haven Home Health, we welcome tough questions from families—it shows you're serious about finding the best care. Below are the 15 questions every family should ask before signing with any home care agency.
 
 ## Questions About the Agency Itself
 
@@ -92,7 +90,7 @@ A technically skilled caregiver isn't enough—personality fit matters enormousl
 
 **What to listen for:** A thoughtful process that considers personality, interests, language needs, cultural background, and specific care requirements. The best agencies take time to understand your loved one as a person, not just a list of medical needs.
 
-At 360 Degree Care, we believe this matching process is one of the most important things we do. We're a small, family-run agency specifically because we want to know every client personally—not treat them as a number in the system.
+At Haven Home Health, we believe this matching process is one of the most important things we do. We're a small, family-run agency specifically because we want to know every client personally—not treat them as a number in the system.
 
 **Red flag:** "We send whoever is available" or no mention of compatibility considerations.
 
@@ -154,7 +152,7 @@ Transparency about costs prevents surprises and builds trust.
 
 **What to listen for:** Clear hourly rates or package pricing, explanation of what's included, and honest discussion of additional costs (if any). Ask about minimum hour requirements, overtime rates, and holiday pricing.
 
-At 360 Degree Care, we provide detailed, personalized quotes after understanding your specific needs. Every family's situation is different, and we believe pricing should reflect the actual care required. For a general overview of what to expect, see our guide on [home care costs in Northern New Jersey](/blog/cost-of-home-care-northern-new-jersey).
+At Haven Home Health, we provide detailed, personalized quotes after understanding your specific needs. Every family's situation is different, and we believe pricing should reflect the actual care required. For a general overview of what to expect, see our guide on [home care costs in Northern New Jersey](/blog/cost-of-home-care-northern-new-jersey).
 
 **Red flag:** Reluctance to discuss pricing, hidden fees, or rates that seem too good to be true.
 
@@ -187,7 +185,7 @@ Beyond questioning the agency, ask yourself:
 
 The home care industry includes both exceptional agencies and those cutting corners. These questions help you identify which is which before you commit.
 
-At 360 Degree Care, we're a family-run agency because we believe home care should feel personal. When you call us, you're not talking to a call center—you're talking to people who genuinely care about getting this decision right for your family.
+At Haven Home Health, we're a family-run agency because we believe home care should feel personal. When you call us, you're not talking to a call center—you're talking to people who genuinely care about getting this decision right for your family.
 
 We serve families throughout Bergen County and Passaic County, from Ridgewood and Paramus to Hackensack, Teaneck, Fort Lee, and beyond. Every client receives individualized attention because that's the only way to provide excellent care.
 
@@ -206,9 +204,9 @@ You're not stuck. Most agency agreements allow you to end services with reasonab
 
 ## Ready to Ask Us These Questions?
 
-We welcome the opportunity to answer every question on this list—and any others you might have. At 360 Degree Care, we believe the best client relationships start with honest conversations.
+We welcome the opportunity to answer every question on this list—and any others you might have. At Haven Home Health, we believe the best client relationships start with honest conversations.
 
-[Contact us to schedule a consultation](/contact/services) or call us at [(201) 299-4243](tel:2012994243). Our team is ready to discuss your family's needs and explain exactly how we can help. No pressure, no obligations—just straightforward answers from people who care.`
+[Contact us to schedule a consultation](/contact/services) or call us at [(555) 123-4567](tel:5551234567). Our team is ready to discuss your family's needs and explain exactly how we can help. No pressure, no obligations—just straightforward answers from people who care.`
 }
 
 export default questionsToAskHomeCareAgency


### PR DESCRIPTION
## Summary
- Debranded all 29 blog articles (28 in `2025/`, 1 in `2026/`) for portfolio demo conversion
- Replaced "360 Degree Care" / "360 Care" / "360DC" with "Haven Home Health" across titles, body content, and meta descriptions
- Changed author names: "Jeff DeJoseph" to "Haven Health Editorial", "360 Degree Care Team" to "Haven Home Health Team"
- Replaced phone number `(201) 299-4243` with `(555) 123-4567`
- Replaced URLs `360degreecare.net` with `haven-home-health.netlify.app`
- Updated avatar references from `getImgSrc('360Logo')` to `'/logo.png'`
- Rewrote Jeff DeJoseph bio lines to generic Haven Home Health attribution

## Test plan
- [ ] Verify no remaining "360" brand references in `src/lib/blogs/articles/`
- [ ] Verify blog index page renders without errors
- [ ] Spot-check individual blog article pages for correct brand name
- [ ] Confirm author names display correctly on blog cards and article pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)