### PR TITLE
DEV-544: Disconnect contact forms from CRM API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,9 @@
 # 360 Degree Care - Environment Variables
 # Copy this file to .env.local and fill in the values
 
-# CRM/Contact API (Required for contact forms)
-NEXT_PUBLIC_API_HOST=https://api.yourdomain.com
-NEXT_PUBLIC_SLUG=your-client-slug-here
+# CRM/Contact API (Not needed for portfolio demo - forms simulate submission)
+# NEXT_PUBLIC_API_HOST=https://api.yourdomain.com
+# NEXT_PUBLIC_SLUG=your-client-slug-here
 
 # Deployment Tracking (Local Git Hooks Only - NOT needed in Netlify/Vercel)
 PVS_WEBSITE_ID=your-website-uuid-here

--- a/src/components/contact/ContactForm.tsx
+++ b/src/components/contact/ContactForm.tsx
@@ -49,32 +49,9 @@ export default function ContactForm() {
     const onSubmit = async (values: z.infer<typeof config.schema>) => {
         setLoading(true)
         try {
-            const payload = {
-                fullname: values.fullname,
-                email: values.email,
-                phone: values.phone,
-                data: {
-                    description: values.description
-                }
-            }
+            // Simulate network delay for demo purposes
+            await new Promise(resolve => setTimeout(resolve, 1000))
 
-            if (config.type !== 'general') {
-                payload.data = {
-                    ...payload.data,
-                    [config.type]: values[config.type]
-                }
-            }
-
-            await fetch(
-                `${process.env.NEXT_PUBLIC_API_HOST}/v1/contact-forms/${process.env.NEXT_PUBLIC_SLUG}`,
-                {
-                    method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json'
-                    },
-                    body: JSON.stringify(payload)
-                }
-            )
             setLoading(false)
             setSubmitted(true)
             return toast.success('Request submitted successfully')


### PR DESCRIPTION
## Summary
- Replaced the `fetch()` call in `ContactForm.tsx` with a simulated 1-second delay so forms still show validation, loading spinner, and success toast without hitting the CRM API
- Commented out `NEXT_PUBLIC_API_HOST` and `NEXT_PUBLIC_SLUG` in `.env.example` since they are no longer needed for the portfolio demo

## Test plan
- [ ] Fill out a contact form with valid data and confirm the loading spinner appears for ~1s followed by the success toast
- [ ] Submit with invalid data and confirm Zod validation errors still display
- [ ] Verify no network requests are made to the CRM endpoint on form submission
- [ ] Confirm the success view (`ContactSuccessMessage`) renders after simulated submission

Generated with [Claude Code](https://claude.com/claude-code)